### PR TITLE
Use dict primitive operations to avoid usage of locking

### DIFF
--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -20,17 +20,13 @@ class BaseCache(object):
 class DictCache(BaseCache):
 
     def __init__(self, init_dict=None):
-        self.lock = Lock()
         self.data = init_dict or {}
 
     def get(self, key):
         return self.data.get(key, None)
 
     def set(self, key, value):
-        with self.lock:
-            self.data.update({key: value})
+        self.data[key] = value
 
     def delete(self, key):
-        with self.lock:
-            if key in self.data:
-                self.data.pop(key)
+        self.data.pop(key, None)


### PR DESCRIPTION
As far as I've understood Python, the following should not require any locks http://docs.python.org/2/glossary.html#term-global-interpreter-lock:
"The mechanism used by the CPython interpreter to assure that only one thread executes Python bytecode at a time. This simplifies the CPython implementation by making the object model (including critical built-in types such as dict) implicitly safe against concurrent access." All other implementations I know of that have no  GIL use explicit locking to imitate this behaviour.
