### PR TITLE
Switched to md5 encoded keys in file cache

### DIFF
--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -1,6 +1,7 @@
 import os
-import base64
 import codecs
+
+from hashlib import md5
 
 try:
     from pickle import load, dump
@@ -20,8 +21,7 @@ class FileCache(object):
             os.mkdir(self.directory)
 
     def encode(self, x):
-        x = codecs.encode(x)
-        return codecs.decode(base64.b64encode(x), "ascii")
+        return md5(x.encode()).hexdigest()
 
     def _fn(self, name):
         return os.path.join(self.directory, self.encode(name))

--- a/tests/test_storage_filecache.py
+++ b/tests/test_storage_filecache.py
@@ -1,12 +1,25 @@
 """
 Unit tests that verify FileCache storage works correctly.
 """
+
+import string
+
+from random import randint, sample
+
 import pytest
 import requests
 from cachecontrol import CacheControl
 from cachecontrol.caches import FileCache
 
 STORAGE_FOLDER = ".cache"
+
+
+def randomdata():
+    """Plain random http data generator:"""
+    key = ''.join(sample(string.ascii_lowercase, randint(2,4)))
+    val = ''.join(sample(string.ascii_lowercase + string.digits ,
+                                                 randint(2,10)))
+    return '&{0}={1}'.format(key, val)
 
 
 class TestStorageFileCache(object):
@@ -23,3 +36,17 @@ class TestStorageFileCache(object):
         assert not response.from_cache
         response = sess.get(self.url)
         assert response.from_cache
+
+    def test_key_length(self, sess):
+        """
+        Hash table keys:
+           Most file systems have a 255 characters path limitation.
+              * Make sure hash method does not produce too long keys
+              * Ideally hash method generate fixed length keys
+        """
+        url0 = url1 = 'http://example.org/res?a=1'
+        while len(url0) < 255:
+            url0 += randomdata()
+            url1 += randomdata()
+        assert len(self.cache.encode(url0)) < 200
+        assert len(self.cache.encode(url0)) == len(self.cache.encode(url1))


### PR DESCRIPTION
Previous b64-encoded keys may generate rather large hash table keys
which tend to hit file system limit - usually 255 characters (closes #10).
