### PR TITLE
FileCache: raw field serialization

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -58,10 +58,10 @@ class CacheControlAdapter(HTTPAdapter):
                 resp = self.controller.update_cached_response(
                     request, response
                 )
-                # Fix possible exception to use missing raw fiel
-                # by requests
-                # TODO: remove when requests will be bump to 2.2.2
-                # or 2.3 version
+                # Fix possible exception when using missing `raw` field in
+                # requests
+                # TODO: remove when requests will be bump to 2.2.2 or 2.3
+                # version
                 resp.raw = None
             else:
                 # try to cache the response


### PR DESCRIPTION
Pickle don't serialize raw field of Response for some reason. And after recover Response from cache this field is not valid.

adapter.py

``` python
 def build_response(self, request, response):
...
    elif request.method == 'GET':
            if response.status == 304:
                # We must have sent an ETag request. This could mean
                # that we've been expired already or that we simply
                # have an etag. In either case, we want to try and
                # update the cache if that is the case.
                resp = self.controller.update_cached_response(
                    request, response
                )
```

controller.py

``` python
def update_cached_response(self, request, response):
        """On a 304 we will get a new set of headers that we want to
        update our cached value with, assuming we have one.

        This should only ever be called when we've sent an ETag and
        gotten a 304 as the response.
        """
        cache_url = self.cache_url(request.url)

        resp = self.cache.get(cache_url)
```

Then here we catch exception:
sessions.py from request

``` python
def send(self, request, **kwargs):
...
       # Response manipulation hooks
        r = dispatch_hook('response', hooks, r, **kwargs)
...
        extract_cookies_to_jar(self.cookies, request, r.raw)
```

``` python
File "/mnt/data/work/projects/autocompas/parser.py", line 79, in check_car
    r = session.get(image)
  File "/mnt/data/work/projects/autocompas/env/lib/python2.7/site-packages/requests/sessions.py", line 395, in get
    return self.request('GET', url, **kwargs)
  File "/mnt/data/work/projects/autocompas/env/lib/python2.7/site-packages/requests/sessions.py", line 383, in request
    resp = self.send(prep, **send_kwargs)
  File "/mnt/data/work/projects/autocompas/env/lib/python2.7/site-packages/requests/sessions.py", line 498, in send
    extract_cookies_to_jar(self.cookies, request, r.raw)
AttributeError: 'Response' object has no attribute 'raw'
```
