### PR TITLE
use highest protocol version for pickling

### DIFF
--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -35,7 +35,7 @@ class FileCache(object):
                 if sys.version < '3':
                     return load(fh)
                 else:
-                    return load(fh, encoding='utf-8')
+                    return load(fh, encoding='latin1')
             except ValueError:
                 return None
 


### PR DESCRIPTION
This is a very rare situation, when used old cache data from one environment to another with lower python version. I think it makes no sense to use the old ASCII protocol.
