### PR TITLE
Use explicit relative imports

### DIFF
--- a/cachecontrol/__init__.py
+++ b/cachecontrol/__init__.py
@@ -6,8 +6,8 @@ Make it easy to import from cachecontrol without long namespaces.
 # patch our requests.models.Response to make them pickleable in older
 # versions of requests.
 
-import cachecontrol.patch_requests
+from . import patch_requests
 
-from cachecontrol.wrapper import CacheControl
-from cachecontrol.adapter import CacheControlAdapter
-from cachecontrol.controller import CacheController
+from .wrapper import CacheControl
+from .adapter import CacheControlAdapter
+from .controller import CacheController

--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -1,7 +1,7 @@
 from requests.adapters import HTTPAdapter
 
-from cachecontrol.controller import CacheController
-from cachecontrol.cache import DictCache
+from .controller import CacheController
+from .cache import DictCache
 
 
 class CacheControlAdapter(HTTPAdapter):

--- a/cachecontrol/caches/__init__.py
+++ b/cachecontrol/caches/__init__.py
@@ -1,7 +1,7 @@
 from textwrap import dedent
 
 try:
-    from cachecontrol.caches.file_cache import FileCache
+    from .file_cache import FileCache
 except ImportError:
     notice = dedent('''
     NOTE: In order to use the FileCache you must have
@@ -13,6 +13,6 @@ except ImportError:
 
 try:
     import redis
-    from cachecontrol.caches.redis_cache import RedisCache
+    from .redis_cache import RedisCache
 except ImportError:
     pass

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -5,8 +5,8 @@ import re
 import calendar
 import time
 
-from cachecontrol.cache import DictCache
-from cachecontrol.compat import parsedate_tz
+from .cache import DictCache
+from .compat import parsedate_tz
 
 
 URI = re.compile(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?")

--- a/cachecontrol/wrapper.py
+++ b/cachecontrol/wrapper.py
@@ -1,5 +1,5 @@
-from cachecontrol.adapter import CacheControlAdapter
-from cachecontrol.cache import DictCache
+from .adapter import CacheControlAdapter
+from .cache import DictCache
 
 
 def CacheControl(sess, cache=None, cache_etags=True):


### PR DESCRIPTION
This uses explicit relative imports to make bundling cachecontrol inside of another project easier.
