### PR TITLE
Use sha224 instead of md5 to key the FileCache

### DIFF
--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -1,6 +1,6 @@
+import hashlib
 import os
 import sys
-from hashlib import md5
 
 try:
     from pickle import load, dump, HIGHEST_PROTOCOL
@@ -20,7 +20,7 @@ class FileCache(object):
 
     @staticmethod
     def encode(x):
-        return md5(x.encode()).hexdigest()
+        return hashlib.sha224(x.encode()).hexdigest()
 
     def _fn(self, name):
         return os.path.join(self.directory, self.encode(name))


### PR DESCRIPTION
MD5 is vulnerable to collision attacks which it may be possible to use to attack a project using CacheControl. There are no known theoretical or practical attacks against the sha-2 family of hash functions so use one of them instead. sha224 is selected due to the smaller digest size which will be less likely to hit edge cases in filename sizes.
