### PR TITLE
Use os.open to ensure that files for the cache have correct perms

### DIFF
--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -10,13 +10,55 @@ except ImportError:
 from lockfile import FileLock
 
 
+def _secure_open_write(filename, fmode):
+    # We only want to write to this file, so open it in write only mode
+    flags = os.O_WRONLY
+
+    # os.O_CREAT | os.O_EXCL will fail if the file already exists, so we only
+    #  will open *new* files.
+    # We specify this because we want to ensure that the mode we pass is the
+    # mode of the file.
+    flags |= os.O_CREAT | os.O_EXCL
+
+    # Do not follow symlinks to prevent someone from making a symlink that
+    # we follow and insecurely open a cache file.
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    # On Windows we'll mark this file as binary
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+
+    # Before we open our file, we want to delete any existing file that is
+    # there
+    try:
+        os.remove(filename)
+    except (IOError, OSError):
+        # The file must not exist already, so we can just skip ahead to opening
+        pass
+
+    # Open our file, the use of os.O_CREAT | os.O_EXCL will ensure that if a
+    # race condition happens between the os.remove and this line, that an
+    # error will be raised. Because we utilize a lockfile this should only
+    # happen if someone is attempting to attack us.
+    fd = os.open(filename, flags, fmode)
+    try:
+        return os.fdopen(fd, "wb")
+    except:
+        # An error occurred wrapping our FD in a file object
+        os.close(fd)
+        raise
+
+
 class FileCache(object):
-    def __init__(self, directory, forever=False):
+    def __init__(self, directory, forever=False, filemode=0o0600,
+                 dirmode=0o0700):
         self.directory = directory
         self.forever = forever
+        self.filemode = filemode
 
         if not os.path.isdir(self.directory):
-            os.mkdir(self.directory)
+            os.makedirs(self.directory, dirmode)
 
     @staticmethod
     def encode(x):
@@ -42,7 +84,7 @@ class FileCache(object):
     def set(self, key, value):
         name = self._fn(key)
         with FileLock(name) as lock:
-            with open(lock.path, 'wb') as fh:
+            with _secure_open_write(lock.path, self.filemode) as fh:
                 dump(value, fh, HIGHEST_PROTOCOL)
 
     def delete(self, key):


### PR DESCRIPTION
The previous file handling code suffered from a few issues.
1. It would only create the leaf directory if it didn't exist but would error if any parent directories didn't exist. This will use os.makedirs to create anything needed.
2. Directories created by FileCache uses the default umask, instead we'll make this configurable and make it default to 0700 which will prevent any access from anyone but the user who owns the process.
3. Files created by FileCache use the default umask, instead we'll make this configurable and make it defalt to 0600 so only the user who owns the process can read/write them.
4. Following the cache file mode bits above, we'll also ensure that we create the files securely to prevent against symlink attacks or someone dropping a file with bad permissions before we open it.
