### PR TITLE
Lazily cache the response once it has been naturally consumed

### DIFF
--- a/cachecontrol/compat.py
+++ b/cachecontrol/compat.py
@@ -24,3 +24,8 @@ try:
     from requests.packages.urllib3.response import HTTPResponse
 except ImportError:
     from urllib3.response import HTTPResponse
+
+try:
+    from requests.packages.urllib3.util import is_fp_closed
+except ImportError:
+    from urllib3.util import is_fp_closed

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -163,7 +163,7 @@ class CacheController(object):
 
         return new_headers
 
-    def cache_response(self, request, response):
+    def cache_response(self, request, response, body=None):
         """
         Algorithm for caching requests.
 
@@ -188,7 +188,10 @@ class CacheController(object):
 
         # If we've been given an etag, then keep the response
         if self.cache_etags and 'etag' in response_headers:
-            self.cache.set(cache_url, self.serializer.dumps(request, response))
+            self.cache.set(
+                cache_url,
+                self.serializer.dumps(request, response, body=body),
+            )
 
         # Add to the cache if the response headers demand it. If there
         # is no date header then we can't do anything about expiring
@@ -199,7 +202,7 @@ class CacheController(object):
                 if int(cc['max-age']) > 0:
                     self.cache.set(
                         cache_url,
-                        self.serializer.dumps(request, response),
+                        self.serializer.dumps(request, response, body=body),
                     )
 
             # If the request can expire, it means we should cache it
@@ -208,7 +211,7 @@ class CacheController(object):
                 if response_headers['expires']:
                     self.cache.set(
                         cache_url,
-                        self.serializer.dumps(request, response),
+                        self.serializer.dumps(request, response, body=body),
                     )
 
     def update_cached_response(self, request, response):

--- a/cachecontrol/filewrapper.py
+++ b/cachecontrol/filewrapper.py
@@ -1,0 +1,33 @@
+from .compat import is_fp_closed
+
+
+class CallbackFileWrapper(object):
+    """
+    Small wrapper around a fp object which will tee everything read into a
+    buffer, and when that file is closed it will execute a callback with the
+    contents of that buffer.
+
+    All attributes are proxied to the underlying file object.
+
+    This class uses members with a double underscore (__) leading prefix so as
+    not to accidentally shadow an attribute.
+    """
+
+    def __init__(self, fp, callback):
+        self.__buf = b""
+        self.__fp = fp
+        self.__callback = callback
+
+    def __getattr__(self, name):
+        return getattr(self.__fp, name)
+
+    def read(self, amt=None):
+        data = self.__fp.read(amt)
+        self.__buf += data
+
+        # Is this the best way to figure out if the file has been completely
+        #   consumed?
+        if is_fp_closed(self.__fp):
+            self.__callback(self.__buf)
+
+        return data

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -11,8 +11,6 @@ class Serializer(object):
         response_headers = CaseInsensitiveDict(response.headers)
 
         if body is None:
-            # TODO: Figure out a way to handle this which doesn't break
-            #   streaming
             body = response.read(decode_content=False)
             response._fp = io.BytesIO(body)
 

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -79,7 +79,7 @@ class TestCacheControllerResponse(object):
                           'date': now})
         req = self.req()
         cc.cache_response(req, resp)
-        cc.serializer.dumps.assert_called_with(req, resp)
+        cc.serializer.dumps.assert_called_with(req, resp, body=None)
         cc.cache.set.assert_called_with(self.url, ANY)
 
     def test_cache_repsonse_no_store(self):

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -8,7 +8,7 @@ from cachecontrol.compat import urljoin
 
 class NullSerializer(object):
 
-    def dumps(self, request, response):
+    def dumps(self, request, response, body=None):
         return response
 
     def loads(self, request, data):

--- a/tests/test_max_age.py
+++ b/tests/test_max_age.py
@@ -8,7 +8,7 @@ from cachecontrol.cache import DictCache
 
 class NullSerializer(object):
 
-    def dumps(self, request, response):
+    def dumps(self, request, response, body=None):
         return response
 
     def loads(self, request, data):


### PR DESCRIPTION
This makes it so `stream=True` works with CacheControl again. It does this by wrapping the underlying file object that an urllib3 `HTTPResponse` class uses with a proxy object which will tee the read data into a buffer, and then once the underlying file object is closed it will execute the registered callback. In this case the callback is the method that will actually store the response in the cache.

The effect of this is that caching happens when the response is consumed, instead of CacheControl consuming the response to be able to cache it. This could be minorly backwards incompatible in that unless the caller of the code actually consumes the entire response (with `stream=True`) the response won't actually be cached whereas before it was because CacheControl consumed it for them. There is no difference for calls without `stream=True`.

It's hard to show an example of this working, however if you run:

``` python
from cachecontrol import CacheControl
import requests
import logging; logging.basicConfig(level=logging.DEBUG)
s = CacheControl(requests.session())
r = s.get("https://pypi.python.org/packages/source/m/matplotlib/matplotlib-1.3.1.tar.gz", stream=True)
for i, c in enumerate(r.iter_content(4096)):
    print("Chunk #{}".format(i))
    break
```

Using `time` you can see the difference.

**Without this PR:**

``` console
$ time python check.py
INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): pypi.python.org
DEBUG:requests.packages.urllib3.connectionpool:"GET /packages/source/m/matplotlib/matplotlib-1.3.1.tar.gz HTTP/1.1" 200 42702580
Chunk #0
python t.py  0.53s user 0.45s system 12% cpu 7.821 total
```

**With this PR:**

``` console
$ time python check.py
INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): pypi.python.org
DEBUG:requests.packages.urllib3.connectionpool:"GET /packages/source/m/matplotlib/matplotlib-1.3.1.tar.gz HTTP/1.1" 200 42702580
Chunk #0
python t.py  0.14s user 0.03s system 20% cpu 0.803 total
```

The shorter time being because it only actually downloads the first chunk vs downloading the entire thing.
