### PR TITLE
Explicitly defreference the callback to fix subtle gc bugs

### DIFF
--- a/cachecontrol/filewrapper.py
+++ b/cachecontrol/filewrapper.py
@@ -32,4 +32,11 @@ class CallbackFileWrapper(object):
         if is_fp_closed(self.__fp):
             self.__callback(self.__buf.getvalue())
 
+            # We assign this to None here, because otherwise we can get into
+            # really tricky problems where the CPython interpreter dead locks
+            # because the callback is holding a reference to something which
+            # has a __del__ method. Setting this to None breaks the cycle
+            # and allows the garbage collector to do it's thing normally.
+            self.__callback = None
+
         return data


### PR DESCRIPTION
Basically this turned out to be the solution to a super annoying pip bug that has been driving me crazy, you can see details on SO here: https://stackoverflow.com/questions/24522467/python-program-hangs-forever-when-called-from-subprocess

I'd love for this to get merged and a release cut because this is making it hard to land any PRs in pip right now.
