### PR TITLE
Add trove classifiers indicating supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ setup_params = dict(
         'Environment :: Web Environment',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP',
     ],
 )


### PR DESCRIPTION
It's good practice to declare which Python versions are supported using Trove classifiers. I suspect that cachecontrol supports 2.6+. Please adjust as necessary.
