### PR TITLE
Python 2.6 and later have the 'utils' module so use it directly.

### DIFF
--- a/cachecontrol/compat.py
+++ b/cachecontrol/compat.py
@@ -5,14 +5,6 @@ except ImportError:
 
 
 try:
-    import email.utils
-    parsedate_tz = email.utils.parsedate_tz
-except ImportError:
-    import email.Utils
-    parsedate_tz = email.Utils.parsedate_tz
-
-
-try:
     import cPickle as pickle
 except ImportError:
     import pickle

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -4,11 +4,11 @@ The httplib2 algorithms ported for use with requests.
 import re
 import calendar
 import time
+from email.utils import parsedate_tz
 
 from requests.structures import CaseInsensitiveDict
 
 from .cache import DictCache
-from .compat import parsedate_tz
 from .serialize import Serializer
 
 


### PR DESCRIPTION
If Python 2.6 is the minimum supported Python version, then the conditional import for emails.Utils is unnecessary.
