### PR TITLE
Properly release the connection to the pool on 304

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -66,6 +66,13 @@ class CacheControlAdapter(HTTPAdapter):
                 if cached_response is not response:
                     from_cache = True
 
+                # We are done with the server response, read a
+                # possible response body (compliant servers will
+                # not return one, but we cannot be 100% sure) and
+                # release the connection back to the pool.
+                response.read(decode_content=None)
+                response.release_conn()
+
                 response = cached_response
             else:
                 if self.heuristic:


### PR DESCRIPTION
When successfully doing a validation request, `cachecontrol` doesn't release the connection back to the urllib3 connection pool. As a consequence, the pool will wastefully start a new connection at the next request, and the existing connection will only be closed on garbage collection.

To handle this properly, two things need to happen:
- We need to consume and discard the body of the response (even if 403 responses are supposed not to have one, you cannot prevent a server from sending one);
- We need to call `response.release_conn()`.

This is very similar (but lower-level) as what requests itself does [when retrying after a 401](https://github.com/kennethreitz/requests/blob/master/requests/auth.py#L169).
