### PR TITLE
feature - adding ability to set the amount of bytes cached

### DIFF
--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -1,5 +1,7 @@
 import hashlib
 import os
+import sys
+import warnings
 
 from lockfile import FileLock
 
@@ -44,13 +46,20 @@ def _secure_open_write(filename, fmode):
         raise
 
 
+def warning_on_one_line(message, category, filename, lineno, file=None,
+                        line=None):
+    return ' %s:%s: %s' % (filename, lineno, message)
+
 class FileCache(object):
     def __init__(self, directory, forever=False, filemode=0o0600,
-                 dirmode=0o0700):
+                 dirmode=0o0700, max_bytes=1000000000):
         self.directory = directory
         self.forever = forever
         self.filemode = filemode
         self.dirmode = dirmode
+        self.max_bytes = max_bytes
+        self.curr_bytes = 0
+        warnings.formatwarning = warning_on_one_line
 
     @staticmethod
     def encode(x):
@@ -72,6 +81,15 @@ class FileCache(object):
     def set(self, key, value):
         name = self._fn(key)
 
+        new_bytes = sys.getsizeof(value)
+        total = (self.curr_bytes + new_bytes)
+        if total > self.max_bytes:
+            message = "Tried adding %d bytes but %d bytes are currently saved" \
+                      " in the cache and the max_bytes is set to %d.\n" % \
+                      (new_bytes, self.curr_bytes, self.max_bytes)
+            warnings.warn(message)
+            return
+
         # Make sure the directory exists
         try:
             os.makedirs(os.path.dirname(name), self.dirmode)
@@ -82,8 +100,12 @@ class FileCache(object):
             # Write our actual file
             with _secure_open_write(lock.path, self.filemode) as fh:
                 fh.write(value)
+                self.curr_bytes += new_bytes
 
     def delete(self, key):
         name = self._fn(key)
+        value = self.get(key)
+        removed_bytes = sys.getsizeof(value)
         if not self.forever:
             os.remove(name)
+            self.curr_bytes -= removed_bytes

--- a/tests/test_storage_filecache.py
+++ b/tests/test_storage_filecache.py
@@ -83,3 +83,45 @@ class TestStorageFileCache(object):
             url1 += randomdata()
         assert len(self.cache.encode(url0)) < 200
         assert len(self.cache.encode(url0)) == len(self.cache.encode(url1))
+
+    def test_max_bytes(self, tmpdir, sess):
+        """
+        Test that caches the first url but not the second because
+        the maximum bytes have been reached for the cache.
+        """
+        # use a cache with max_bytes set
+        max_bytes = 1400
+        self.cache = FileCache(str(tmpdir), max_bytes=max_bytes)
+        sess = CacheControl(requests.Session(), cache=self.cache)
+
+        url1 = self.url + ''.join(sample(string.ascii_lowercase, randint(2, 4)))
+        url2 = self.url + ''.join(sample(string.ascii_lowercase, randint(2, 4)))
+        assert url1 != url2
+
+        # fill up the cache with url1
+        response = sess.get(url1)
+        assert not response.from_cache
+
+        # make sure it got into the cache
+        response = sess.get(url1)
+        assert response.from_cache
+
+        # do url2 now
+        response = sess.get(url2)
+        assert not response.from_cache
+
+        # make sure url2 was NOT cached
+        response = sess.get(url2)
+        assert not response.from_cache
+
+        # clear the cache
+        response = sess.delete(url1)
+        assert not response.from_cache
+
+        # re-add to cache since bytes should be back to 0
+        response = sess.get(url1)
+        assert not response.from_cache
+
+        # verify from cache again
+        response = sess.get(url1)
+        assert response.from_cache


### PR DESCRIPTION
Hi @ionrock,

I'm working on a feature for http://github.com/mozilla/mozregression in which we could set the maximum bytes that we cache using cachecontrol. This PR adds this capability to the FileCache class with a `max_bytes` param. The default is 1Gb.

The implementation in this PR is using the `sys.getsizeof(value)` to take care of the byte tracking. Another approach might be to do something with [os.path.getsize() like this](http://stackoverflow.com/a/1392549/1183294) against the top cache dir.

Let me know what you think! :)
