### PR TITLE
Add a hook to determine if a response should be cached

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -25,6 +25,7 @@ class CacheControlAdapter(HTTPAdapter):
             self.cache,
             cache_etags=cache_etags,
             serializer=serializer,
+            heuristic=self.heuristic,
         )
 
     def send(self, request, **kw):

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -40,10 +40,14 @@ class BaseHeuristic(object):
         return {}
 
     def apply(self, response):
-        warning_header_value = self.warning(response)
-        response.headers.update(self.update_headers(response))
-        if warning_header_value is not None:
-            response.headers.update({'Warning': warning_header_value})
+        updated_headers = self.update_headers(response)
+
+        if updated_headers:
+            response.headers.update(updated_headers)
+            warning_header_value = self.warning(response)
+            if warning_header_value is not None:
+                response.headers.update({'Warning': warning_header_value})
+
         return response
 
     def should_cache(self, request, response, body):

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -46,6 +46,24 @@ class BaseHeuristic(object):
             response.headers.update({'Warning': warning_header_value})
         return response
 
+    def should_cache(self, request, response, body):
+        """
+        This method allows a Heuristic to control the caching logic. It can
+        return:
+
+        * True, in which case the item will be unconditionally cached.
+        * False, in which case the item will be unconditionally not cached.
+        * None, in which case the item will be conditionally cached based on
+          the standard logic.
+
+        By default, this returns None to continue to use the standard logic.
+        """
+        return None
+
+
+class Heuristic(BaseHeuristic):
+    pass
+
 
 class OneDayCache(BaseHeuristic):
     """


### PR DESCRIPTION
This is primarily useful to add extra logic to _prevent_ the caching of a response, but the way it is implemented it can also be used to add extra logic to _force_ the caching of a response without adjusting the response itself.

In addition this also adjusts the default heuristic a bit so that it only applies the warning header if it's actually going to modify the headers, and not unconditionally. This makes it possible to do a simple thing like:

``` python
import random

from cachecontrol.heuristic import BaseHeuristic

class RandomlyCache(BaseHeuristic):
    def should_cache(self, request, response, body):
        return random.choice([True, False, None])
```

Without having it adjust the content of the request or response at all.
