### PR TITLE
Make msgpack optional: use v2 serialization instead of v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup_params = dict(
     long_description=long_description,
     install_requires=[
         'requests',
-        'msgpack-python',
     ],
     extras_require={
+        'msgpack': ['msgpack-python'],
         'filecache': ['lockfile>=0.9'],
         'redis': ['redis>=2.10.5'],
     },

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -3,9 +3,9 @@ import requests
 
 try:
     import msgpack
-    _with_msgpack = 1
-except:
-    _with_msgpack = 0
+    _with_msgpack = True
+except ImportError:
+    _with_msgpack = False
 
 from mock import Mock
 
@@ -60,7 +60,7 @@ class TestSerializer(object):
         resp = self.serializer.loads(req, data)
         assert resp is None
 
-    @pytest.mark.skipif(_with_msgpack == 0, reason="no msgpack")
+    @pytest.mark.skipif(_with_msgpack == False, reason="no msgpack")
     def test_read_version_v4(self):
         print('\nTesting v4\n')
         req = Mock()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,5 +1,11 @@
-import msgpack
+import pytest
 import requests
+
+try:
+    import msgpack
+    _with_msgpack = 1
+except:
+    _with_msgpack = 0
 
 from mock import Mock
 
@@ -54,7 +60,9 @@ class TestSerializer(object):
         resp = self.serializer.loads(req, data)
         assert resp is None
 
+    @pytest.mark.skipif(_with_msgpack == 0, reason="no msgpack")
     def test_read_version_v4(self):
+        print('\nTesting v4\n')
         req = Mock()
         resp = self.serializer._loads_v4(req, msgpack.dumps(self.response_data))
         # We have to decode our urllib3 data back into a unicode string.


### PR DESCRIPTION
This gives us freedom to choose not to install msgpack.