### PR TITLE
fix streaming error "Unable to determine whether fp is closed."

### DIFF
--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -127,6 +127,8 @@ class Serializer(object):
         try:
             if body_file is None:
                 body = io.BytesIO(body_raw)
+            elif not hasattr(body_file, "read"):
+                body = io.BytesIO(body_file)
             else:
                 body = body_file
         except TypeError:


### PR DESCRIPTION
trying to fix bug with new SeparateBodyBaseCache, 

hit this when I write a custom SQLite cache backend with streaming resp.