### PR TITLE
fix: use pytest native method name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@
     :target: https://pypi.python.org/pypi/cachecontrol
     :alt: Latest Version
 
-.. image:: https://travis-ci.org/ionrock/cachecontrol.png?branch=master
-  :target: https://travis-ci.org/ionrock/cachecontrol
+.. image:: https://github.com/psf/cachecontrol/actions/workflows/tests.yml/badge.svg
+  :target: https://github.com/psf/cachecontrol/actions/workflows/tests.yml
 
 CacheControl is a port of the caching algorithms in httplib2_ for use with
 requests_ session object.

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -5,18 +5,19 @@
 """
 Unit tests that verify our caching methods work correctly.
 """
-import pytest
-from unittest.mock import ANY, Mock
 import time
 from tempfile import mkdtemp
+from unittest.mock import ANY, Mock
+
+import pytest
 
 from cachecontrol import CacheController
 from cachecontrol.cache import DictCache
 from cachecontrol.caches import SeparateBodyFileCache
-from .utils import NullSerializer, DummyResponse, DummyRequest
+
+from .utils import DummyRequest, DummyResponse, NullSerializer
 
 TIME_FMT = "%a, %d %b %Y %H:%M:%S GMT"
-
 
 
 class TestCacheControllerResponse(object):
@@ -126,13 +127,16 @@ class TestCacheControllerResponse(object):
         cache = DictCache({})
         cc = CacheController(cache)
         req = DummyRequest(url="http://localhost/", headers={"if-match": "xyz"})
-        resp = DummyResponse(status=304, headers={
-            "ETag": "xyz",
-            "x-value": "b",
-            "Date": time.strftime(TIME_FMT, time.gmtime()),
-            "Cache-Control": "max-age=60",
-            "Content-Length": "200"
-        })
+        resp = DummyResponse(
+            status=304,
+            headers={
+                "ETag": "xyz",
+                "x-value": "b",
+                "Date": time.strftime(TIME_FMT, time.gmtime()),
+                "Cache-Control": "max-age=60",
+                "Content-Length": "200",
+            },
+        )
         # First, ensure the response from update_cached_response() matches the
         # cached one:
         result = cc.update_cached_response(req, resp)
@@ -176,13 +180,16 @@ class TestCacheControllerResponse(object):
         cc = CacheController(cache)
         url = "http://localhost:123/x"
         req = DummyRequest(url=url, headers={})
-        cached_resp = DummyResponse(status=200, headers={
-            "ETag": etag,
-            "x-value:": "a",
-            "Content-Length": "100",
-            "Cache-Control": "max-age=60",
-            "Date": time.strftime(TIME_FMT, time.gmtime()),
-        })
+        cached_resp = DummyResponse(
+            status=200,
+            headers={
+                "ETag": etag,
+                "x-value:": "a",
+                "Content-Length": "100",
+                "Cache-Control": "max-age=60",
+                "Date": time.strftime(TIME_FMT, time.gmtime()),
+            },
+        )
         cc._cache_set(url, req, cached_resp, b"my body")
 
         # Now we get another request, and it's a 304, with new value for
@@ -191,13 +198,16 @@ class TestCacheControllerResponse(object):
         # Set our content length to 200. That would be a mistake in
         # the server, but we'll handle it gracefully... for now.
         req = DummyRequest(url=url, headers={"if-match": etag})
-        resp = DummyResponse(status=304, headers={
-            "ETag": etag,
-            "x-value": "b",
-            "Date": time.strftime(TIME_FMT, time.gmtime()),
-            "Cache-Control": "max-age=60",
-            "Content-Length": "200"
-        })
+        resp = DummyResponse(
+            status=304,
+            headers={
+                "ETag": etag,
+                "x-value": "b",
+                "Date": time.strftime(TIME_FMT, time.gmtime()),
+                "Cache-Control": "max-age=60",
+                "Content-Length": "200",
+            },
+        )
         # First, ensure the response from update_cached_response() matches the
         # cached one:
         result = cc.update_cached_response(req, resp)
@@ -214,7 +224,7 @@ class TestCacheControllerResponse(object):
 class TestCacheControlRequest(object):
     url = "http://foo.com/bar"
 
-    def setup(self):
+    def setup_method(self):
         self.c = CacheController(DictCache(), serializer=NullSerializer())
 
     def req(self, headers):
@@ -222,7 +232,9 @@ class TestCacheControlRequest(object):
         return self.c.cached_request(mock_request)
 
     def test_cache_request_no_headers(self):
-        cached_resp = Mock(headers={"ETag": "jfd9094r808", "Content-Length": 100}, status=200)
+        cached_resp = Mock(
+            headers={"ETag": "jfd9094r808", "Content-Length": 100}, status=200
+        )
         self.c.cache = DictCache({self.url: cached_resp})
         resp = self.req({})
         assert not resp

--- a/tests/test_expires_heuristics.py
+++ b/tests/test_expires_heuristics.py
@@ -4,26 +4,27 @@
 
 import calendar
 import time
-
-from email.utils import formatdate, parsedate
 from datetime import datetime
-
+from email.utils import formatdate, parsedate
+from pprint import pprint
 from unittest.mock import Mock
+
 from requests import Session, get
 
 from cachecontrol import CacheControl
-from cachecontrol.heuristics import LastModified, ExpiresAfter, OneDayCache
-from cachecontrol.heuristics import TIME_FMT
-from cachecontrol.heuristics import BaseHeuristic
-from .utils import DummyResponse
+from cachecontrol.heuristics import (
+    TIME_FMT,
+    BaseHeuristic,
+    ExpiresAfter,
+    LastModified,
+    OneDayCache,
+)
 
-from pprint import pprint
+from .utils import DummyResponse
 
 
 class TestHeuristicWithoutWarning(object):
-
-    def setup(self):
-
+    def setup_method(self):
         class NoopHeuristic(BaseHeuristic):
             warning = Mock()
 
@@ -35,17 +36,14 @@ class TestHeuristicWithoutWarning(object):
 
     def test_no_header_change_means_no_warning_header(self, url):
         the_url = url + "optional_cacheable_request"
-        resp = self.sess.get(the_url)
+        self.sess.get(the_url)
 
         assert not self.heuristic.warning.called
 
 
 class TestHeuristicWith3xxResponse(object):
-
-    def setup(self):
-
+    def setup_method(self):
         class DummyHeuristic(BaseHeuristic):
-
             def update_headers(self, resp):
                 return {"x-dummy-header": "foobar"}
 
@@ -63,7 +61,6 @@ class TestHeuristicWith3xxResponse(object):
 
 
 class TestUseExpiresHeuristic(object):
-
     def test_expires_heuristic_arg(self):
         sess = Session()
         cached_sess = CacheControl(sess, heuristic=Mock())
@@ -71,8 +68,7 @@ class TestUseExpiresHeuristic(object):
 
 
 class TestOneDayCache(object):
-
-    def setup(self):
+    def setup_method(self):
         self.sess = Session()
         self.cached_sess = CacheControl(self.sess, heuristic=OneDayCache())
 
@@ -91,8 +87,7 @@ class TestOneDayCache(object):
 
 
 class TestExpiresAfter(object):
-
-    def setup(self):
+    def setup_method(self):
         self.sess = Session()
         self.cache_sess = CacheControl(self.sess, heuristic=ExpiresAfter(days=1))
 
@@ -112,8 +107,7 @@ class TestExpiresAfter(object):
 
 
 class TestLastModified(object):
-
-    def setup(self):
+    def setup_method(self):
         self.sess = Session()
         self.cached_sess = CacheControl(self.sess, heuristic=LastModified())
 
@@ -136,11 +130,10 @@ def datetime_to_header(dt):
 
 
 class TestModifiedUnitTests(object):
-
     def last_modified(self, period):
         return time.strftime(TIME_FMT, time.gmtime(self.time_now - period))
 
-    def setup(self):
+    def setup_method(self):
         self.heuristic = LastModified()
         self.time_now = time.time()
         day_in_seconds = 86400

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -11,8 +11,7 @@ from cachecontrol import CacheControl
 
 
 class TestPermanentRedirects(object):
-
-    def setup(self):
+    def setup_method(self):
         self.sess = CacheControl(requests.Session())
 
     def test_redirect_response_is_cached(self, url):
@@ -33,8 +32,7 @@ class TestPermanentRedirects(object):
 
 
 class TestMultipleChoicesRedirects(object):
-
-    def setup(self):
+    def setup_method(self):
         self.sess = CacheControl(requests.Session())
 
     def test_multiple_choices_is_cacheable(self, url):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -12,7 +12,7 @@ from cachecontrol.serialize import Serializer
 
 
 class TestSerializer(object):
-    def setup(self):
+    def setup_method(self):
         self.serializer = Serializer()
         self.response_data = {
             "response": {

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -3,14 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
-
 from unittest.mock import Mock
+
 from cachecontrol.caches import RedisCache
 
 
 class TestRedisCache(object):
-
-    def setup(self):
+    def setup_method(self):
         self.conn = Mock()
         self.cache = RedisCache(self.conn)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,8 +4,10 @@ Shared utility classes.
 
 from requests.structures import CaseInsensitiveDict
 
+from cachecontrol.serialize import Serializer
 
-class NullSerializer(object):
+
+class NullSerializer(Serializer):
 
     def dumps(self, request, response, body=None):
         return response


### PR DESCRIPTION
Fix #298

This eliminates the mass warning when running pytest:

```
    tests/test_storage_redis.py::TestRedisCache::test_set_expiration_int is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
    fixture_result = next(generator)
```
Signed-off-by: Frost Ming <me@frostming.com>