### PR TITLE
cachecontrol: 0.13.1

### DIFF
--- a/cachecontrol/__init__.py
+++ b/cachecontrol/__init__.py
@@ -8,7 +8,7 @@ Make it easy to import from cachecontrol without long namespaces.
 """
 __author__ = "Eric Larson"
 __email__ = "eric@ionrock.org"
-__version__ = "0.13.1rc0"
+__version__ = "0.13.1"
 
 from cachecontrol.adapter import CacheControlAdapter
 from cachecontrol.controller import CacheController

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,8 +7,8 @@
  Release Notes
 ===============
 
-Unreleased
-==========
+0.13.1
+======
 
 * Support for old serialization formats has been removed.
 * Move the serialization implementation into own method.
@@ -16,6 +16,8 @@ Unreleased
 
 0.13.0
 ======
+
+**YANKED**
 
 The project has been moved to the `PSF <https://github.com/psf>`_ organization.
 


### PR DESCRIPTION
Preps `0.13.1`.

I'll cut a tag and create the release once approved.