### PR TITLE
serialize: simplify loading logic

### DIFF
--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -72,30 +72,13 @@ class Serializer:
         if not data:
             return None
 
-        # Determine what version of the serializer the data was serialized
-        # with
-        try:
-            ver, data = data.split(b",", 1)
-        except ValueError:
-            ver = b"cc=0"
-
-        # Make sure that our "ver" is actually a version and isn't a false
-        # positive from a , being in the data stream.
-        if ver[:3] != b"cc=":
-            data = ver + data
-            ver = b"cc=0"
-
-        # Get the version number out of the cc=N
-        verstr = ver.split(b"=", 1)[-1].decode("ascii")
-
-        # Dispatch to the actual load method for the given version
-        try:
-            return getattr(self, f"_loads_v{verstr}")(request, data, body_file)  # type: ignore[no-any-return]
-
-        except AttributeError:
-            # This is a version we don't have a loads function for, so we'll
-            # just treat it as a miss and return None
+        # Previous versions of this library supported other serialization
+        # formats, but these have all been removed.
+        if not data.startswith(f"cc={self.serde_version},".encode()):
             return None
+
+        data = data[5:]
+        return self._loads_v4(request, data, body_file)
 
     def prepare_response(
         self,
@@ -148,49 +131,6 @@ class Serializer:
         cached["response"].pop("strict", None)
 
         return HTTPResponse(body=body, preload_content=False, **cached["response"])
-
-    def _loads_v0(
-        self,
-        request: PreparedRequest,
-        data: bytes,
-        body_file: IO[bytes] | None = None,
-    ) -> None:
-        # The original legacy cache data. This doesn't contain enough
-        # information to construct everything we need, so we'll treat this as
-        # a miss.
-        return None
-
-    def _loads_v1(
-        self,
-        request: PreparedRequest,
-        data: bytes,
-        body_file: IO[bytes] | None = None,
-    ) -> HTTPResponse | None:
-        # The "v1" pickled cache format. This is no longer supported
-        # for security reasons, so we treat it as a miss.
-        return None
-
-    def _loads_v2(
-        self,
-        request: PreparedRequest,
-        data: bytes,
-        body_file: IO[bytes] | None = None,
-    ) -> HTTPResponse | None:
-        # The "v2" compressed base64 cache format.
-        # This has been removed due to age and poor size/performance
-        # characteristics, so we treat it as a miss.
-        return None
-
-    def _loads_v3(
-        self,
-        request: PreparedRequest,
-        data: bytes,
-        body_file: IO[bytes] | None = None,
-    ) -> None:
-        # Due to Python 2 encoding issues, it's impossible to know for sure
-        # exactly how to load v3 entries, thus we'll treat these as a miss so
-        # that they get rewritten out as v4 entries.
-        return None
 
     def _loads_v4(
         self,


### PR DESCRIPTION
All other versions are effectively no-ops, so we can remove them entirely, along with their associated version sniffing.