### PR TITLE
pyproject: constrain msgpack < 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 keywords = ["requests", "http", "caching", "web"]
-dependencies = ["requests >= 2.16.0", "msgpack >= 0.5.2"]
+dependencies = ["requests >= 2.16.0", "msgpack >= 0.5.2, < 2.0.0"]
 requires-python = ">=3.7"
 
 [project.urls]


### PR DESCRIPTION
This should prevent us from accidentally selecting a future incompatible version.

Closes #217.