### PR TITLE
Miscellaneous repo cleanup

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,0 @@
-[bumpversion]
-current_version = 0.13.0
-files = cachecontrol/__init__.py docs/conf.py
-commit = True
-tag = True

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ BUMPTYPE=patch
 BUMPPRE=0
 
 
-$(VENV)/bin/pip3:
+$(VENV)/bin/pip:
 	$(VENV_CMD) $(VENV)
 
-bootstrap: $(VENV)/bin/pip3
-	$(VENV)/bin/pip3 install -e .[dev]
+bootstrap: $(VENV)/bin/pip
+	$(VENV)/bin/pip install -e .[dev]
 
 format:
 	$(VENV)/bin/black .

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,6 @@
 VENV=.venv
 VENV_CMD=python3 -m venv
 ACTIVATE = $(VENV)/bin/activate
-CHEESE=https://pypi.python.org/pypi
-BUMPTYPE=patch
-BUMPPRE=0
-
 
 $(VENV)/bin/pip:
 	$(VENV_CMD) $(VENV)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,10 +73,9 @@ If you give it a try, please let me know of any issues.
 
 
 .. _httplib2: https://github.com/httplib2/httplib2
-.. _requests: http://docs.python-requests.org/
-.. _Editing the Web: http://www.w3.org/1999/04/Editing/
-.. _PyPI: https://pypi.python.org/pypi/CacheControl/
-.. _pip: http://www.pip-installer.org/
+.. _requests: https://requests.readthedocs.io/en/latest/
+.. _PyPI: https://pypi.org/project/CacheControl/
+.. _pip: https://pip.pypa.io/en/stable/
 
 
 Contents


### PR DESCRIPTION
* Updates some URLs in the docs
* Uses `pip` instead of `pip3` in the Makefile
* Removes unused Makefile variables
* Removes an unused `bumpversion.cfg` file