### PR TITLE
Add support for Python 3.12 and drop EOL 3.6 and 3.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v4
       with:
@@ -35,7 +35,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: sign
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v2.0.1
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
         release-signing-artifacts: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: ">= 3.6"
+        python-version: "3.x"
 
     - name: deps
       run: python -m pip install -U build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["macos-latest", "windows-latest", "ubuntu-latest"]
 
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
       - name: "Install dependencies"
         run: |
           python -VV

--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -125,21 +125,21 @@ class CacheControlAdapter(HTTPAdapter):
             else:
                 # Wrap the response file with a wrapper that will cache the
                 #   response when the stream has been consumed.
-                response._fp = CallbackFileWrapper(  # type: ignore[attr-defined]
-                    response._fp,  # type: ignore[attr-defined]
+                response._fp = CallbackFileWrapper(  # type: ignore[assignment]
+                    response._fp,  # type: ignore[arg-type]
                     functools.partial(
                         self.controller.cache_response, request, response
                     ),
                 )
                 if response.chunked:
-                    super_update_chunk_length = response._update_chunk_length  # type: ignore[attr-defined]
+                    super_update_chunk_length = response._update_chunk_length
 
                     def _update_chunk_length(self: HTTPResponse) -> None:
                         super_update_chunk_length()
                         if self.chunk_left == 0:
-                            self._fp._close()  # type: ignore[attr-defined]
+                            self._fp._close()  # type: ignore[union-attr]
 
-                    response._update_chunk_length = types.MethodType(  # type: ignore[attr-defined]
+                    response._update_chunk_length = types.MethodType(  # type: ignore[method-assign]
                         _update_chunk_length, response
                     )
 

--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -64,7 +64,7 @@ class _FileCacheMixin:
 
     def __init__(
         self,
-        directory: Union[str, Path],
+        directory: str | Path,
         forever: bool = False,
         filemode: int = 0o0600,
         dirmode: int = 0o0700,

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -480,7 +480,7 @@ class CacheController:
         cached_response.headers.update(
             {
                 k: v
-                for k, v in response.headers.items()  # type: ignore[no-untyped-call]
+                for k, v in response.headers.items()
                 if k.lower() not in excluded_headers
             }
         )

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -68,7 +68,7 @@ class OneDayCache(BaseHeuristic):
 
         if "expires" not in response.headers:
             date = parsedate(response.headers["date"])
-            expires = expire_after(timedelta(days=1), date=datetime(*date[:6], tzinfo=timezone.utc))  # type: ignore[misc]
+            expires = expire_after(timedelta(days=1), date=datetime(*date[:6], tzinfo=timezone.utc))  # type: ignore[index,misc]
             headers["expires"] = datetime_to_header(expires)
             headers["cache-control"] = "public"
         return headers

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -32,13 +32,13 @@ class Serializer:
             # also update the response with a new file handler to be
             # sure it acts as though it was never read.
             body = response.read(decode_content=False)
-            response._fp = io.BytesIO(body)  # type: ignore[attr-defined]
+            response._fp = io.BytesIO(body)  # type: ignore[assignment]
             response.length_remaining = len(body)
 
         data = {
             "response": {
                 "body": body,  # Empty bytestring if body is stored separately
-                "headers": {str(k): str(v) for k, v in response.headers.items()},  # type: ignore[no-untyped-call]
+                "headers": {str(k): str(v) for k, v in response.headers.items()},
                 "status": response.status,
                 "version": response.version,
                 "reason": str(response.reason),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # SPDX-FileCopyrightText: 2015 Eric Larson
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -17,12 +17,12 @@ URL = f"http://{HOST}:{PORT}/"
 
 
 class Server:
-
     def __call__(self, env, sr):
         body = "Hello World!"
         status = "200 OK"
         headers = [
-            ("Cache-Control", "max-age=%i" % (60 * 10)), ("Content-Type", "text/plain")
+            ("Cache-Control", "max-age=%i" % (60 * 10)),
+            ("Content-Type", "text/plain"),
         ]
         sr(status, headers)
         return body

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -13,10 +13,10 @@ from cachecontrol import CacheControl
 
 HOST = "localhost"
 PORT = 8050
-URL = "http://{}:{}/".format(HOST, PORT)
+URL = f"http://{HOST}:{PORT}/"
 
 
-class Server(object):
+class Server:
 
     def __call__(self, env, sr):
         body = "Hello World!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Environment :: Web Environment",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Internet :: WWW/HTTP",
 ]
 keywords = ["requests", "http", "caching", "web"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import cherrypy
 
 
 class SimpleApp:
-
     def __init__(self):
         self.etag_count = 0
         self.update_etag_string()
@@ -109,7 +108,7 @@ class SimpleApp:
         headers = [
             ("Content-Type", "text/plain"),
             ("Cache-Control", "max-age=5000"),
-            ("Content-Length", str(len(body)))
+            ("Content-Length", str(len(body))),
         ]
         start_response("200 OK", headers)
         return [body]

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -35,7 +35,6 @@ def sess(url, request):
 
 
 class TestSessionActions:
-
     def test_get_caches(self, url, sess):
         r2 = sess.get(url)
         assert r2.from_cache is True

--- a/tests/test_chunked_response.py
+++ b/tests/test_chunked_response.py
@@ -21,7 +21,6 @@ def sess():
 
 
 class TestChunkedResponses:
-
     def test_cache_chunked_response(self, url, sess):
         """
         Verify that an otherwise cacheable response is cached when the

--- a/tests/test_max_age.py
+++ b/tests/test_max_age.py
@@ -11,7 +11,6 @@ from .utils import NullSerializer
 
 
 class TestMaxAge:
-
     @pytest.fixture()
     def sess(self, url):
         self.url = url

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -12,7 +12,6 @@ from requests import Session
 
 
 class Test39:
-
     def test_file_cache_recognizes_consumed_file_handle(self, url):
         s = CacheControl(Session(), FileCache("web_cache"))
         the_url = url + "cache_60"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 import pytest
 
 
@@ -14,9 +13,6 @@ from requests import Session
 
 class Test39:
 
-    @pytest.mark.skipif(
-        sys.version.startswith("2"), reason="Only run this for python 3.x"
-    )
     def test_file_cache_recognizes_consumed_file_handle(self, url):
         s = CacheControl(Session(), FileCache("web_cache"))
         the_url = url + "cache_60"

--- a/tests/test_storage_filecache.py
+++ b/tests/test_storage_filecache.py
@@ -25,7 +25,6 @@ def randomdata():
 
 
 class FileCacheTestsMixin:
-
     FileCacheClass = None  # Either FileCache or SeparateBodyFileCache
 
     @pytest.fixture()

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -18,8 +18,7 @@ class TestRedisCache:
         assert self.conn.setex.called
 
     def test_set_expiration_datetime_aware(self):
-        self.cache.set("foo", "bar",
-                       expires=datetime(2014, 2, 2, tzinfo=timezone.utc))
+        self.cache.set("foo", "bar", expires=datetime(2014, 2, 2, tzinfo=timezone.utc))
         assert self.conn.setex.called
 
     def test_set_expiration_int(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,6 @@ from cachecontrol.serialize import Serializer
 
 
 class NullSerializer(Serializer):
-
     def dumps(self, request, response, body=None):
         return response
 
@@ -20,6 +19,7 @@ class NullSerializer(Serializer):
 
 class DummyResponse:
     """Match a ``urllib3.response.HTTPResponse``."""
+
     version = "1.1"
     reason = b"Because"
     strict = 0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 isolated_build = True
-envlist = py{36,37,38,39,310,311,312}, mypy
+envlist = py{37,38,39,310,311,312}, mypy
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 isolated_build = True
-envlist = py{36,37,38,39,310,311}, mypy
+envlist = py{36,37,38,39,310,311,312}, mypy
 
 [gh-actions]
 python =
@@ -13,6 +13,7 @@ python =
        3.9: py39
        3.10: py310, mypy
        3.11: py311
+       3.12: py312
 
 [testenv]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ python =
        3.7: py37
        3.8: py38
        3.9: py39
-       3.10: py310, mypy
+       3.10: py310
        3.11: py311
-       3.12: py312
+       3.12: py312, mypy
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/
