### PR TITLE
github: bump signing step, use dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99
+    rebase-strategy: "disabled"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: sign
-      uses: sigstore/gh-action-sigstore-python@v2.0.1
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
         release-signing-artifacts: true


### PR DESCRIPTION
This adds a Dependabot configuration to keep our actions up-to-date. I've intentionally kept Python dep bumps out of the configuration (only actions), since we only have two deps and they need to be bumped somewhat carefully :slightly_smiling_face: 