### PR TITLE
GitHub Action to spellcheck and lint Python code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
         exclude:
           - python-version: "3.7"
             os: "macos-latest"
-            
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["macos-latest", "windows-latest", "ubuntu-latest"]
-        exclude:
-          - python-version: "3.7"
-            os: "macos-latest"
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["macos-latest", "windows-latest", "ubuntu-latest"]
+        exclude:
+          - python-version: "3.7"
+            os: "macos-latest"
+            
 
     steps:
       - uses: "actions/checkout@v4"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ bootstrap: $(VENV)/bin/pip
 
 format:
 	$(VENV)/bin/codespell
-	$(VENV)/bin/ruff check
+	$(VENV)/bin/ruff check --fix
 	$(VENV)/bin/ruff format
 
 doc: $(VENV)/bin/sphinx-build

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ bootstrap: $(VENV)/bin/pip
 	$(VENV)/bin/pip install -e .[dev]
 
 format:
-	$(VENV)/bin/black .
+	$(VENV)/bin/codespell
+	$(VENV)/bin/ruff check
+	$(VENV)/bin/ruff format
 
 doc: $(VENV)/bin/sphinx-build
 	. $(ACTIVATE);

--- a/cachecontrol/__init__.py
+++ b/cachecontrol/__init__.py
@@ -6,6 +6,7 @@
 
 Make it easy to import from cachecontrol without long namespaces.
 """
+
 __author__ = "Eric Larson"
 __email__ = "eric@ionrock.org"
 __version__ = "0.14.0"

--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -6,6 +6,7 @@
 The cache object API for implementing caches. The default is a thread
 safe in-memory dictionary.
 """
+
 from __future__ import annotations
 
 from threading import Lock

--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import os
 from textwrap import dedent
-from typing import IO, TYPE_CHECKING, Union
+from typing import IO, TYPE_CHECKING
 from pathlib import Path
 
 from cachecontrol.cache import BaseCache, SeparateBodyBaseCache

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -5,6 +5,7 @@
 """
 The httplib2 algorithms ported for use with requests.
 """
+
 from __future__ import annotations
 
 import calendar

--- a/cachecontrol/filewrapper.py
+++ b/cachecontrol/filewrapper.py
@@ -38,10 +38,10 @@ class CallbackFileWrapper:
         self.__callback = callback
 
     def __getattr__(self, name: str) -> Any:
-        # The vaguaries of garbage collection means that self.__fp is
+        # The vagaries of garbage collection means that self.__fp is
         # not always set.  By using __getattribute__ and the private
         # name[0] allows looking up the attribute value and raising an
-        # AttributeError when it doesn't exist. This stop thigns from
+        # AttributeError when it doesn't exist. This stop things from
         # infinitely recursing calls to getattr in the case where
         # self.__fp hasn't been set.
         #

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -68,7 +68,10 @@ class OneDayCache(BaseHeuristic):
 
         if "expires" not in response.headers:
             date = parsedate(response.headers["date"])
-            expires = expire_after(timedelta(days=1), date=datetime(*date[:6], tzinfo=timezone.utc))  # type: ignore[index,misc]
+            expires = expire_after(
+                timedelta(days=1),
+                date=datetime(*date[:6], tzinfo=timezone.utc),  # type: ignore[index,misc]
+            )
             headers["expires"] = datetime_to_header(expires)
             headers["cache-control"] = "public"
         return headers

--- a/docs/etags.rst
+++ b/docs/etags.rst
@@ -18,7 +18,7 @@ expired.
 In CacheControl the default behavior when an ETag is sent by the
 server is to cache the response. We'll refer to this pattern as a
 **Equal Priority** cache as the decision to cache is either time base or
-due to the presense of an ETag.
+due to the presence of an ETag.
 
 The spec is not explicit what takes priority when caching with both
 ETags and time based headers. Therefore, CacheControl supports the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ effort to faithfully port the tests from httplib2 to CacheControl, but
 there is a decent chance that I've missed something. Please file bugs
 if you find any issues!
 
-With that in mind, CacheControl has been used sucessfully in
+With that in mind, CacheControl has been used successfully in
 production environments, replacing httplib2's usage.
 
 If you give it a try, please let me know of any issues.

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -43,7 +43,7 @@ response.
 
 With that in mind, you should be aware that if you try to cache a very
 large response on a network store, you still might have some latency
-tranferring the data from the network store to your
+transferring the data from the network store to your
 application. Another consideration is storing large responses in a
 `FileCache`. If you are caching using ETags and the server is
 extremely specific as to what constitutes an equivalent request, it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,3 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 norecursedirs = ["bin", "lib", "include", "build"]
 
-[tool.ruff]
-target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,15 +50,16 @@ redis = ["redis>=2.10.5"]
 dev = [
     "CacheControl[filecache,redis]",
     "build",
-    "mypy",
-    "tox",
-    "pytest-cov",
-    "pytest",
     "cherrypy",
-    "sphinx",
+    "codespell[tomli]",
     "furo",
+    "mypy",
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "sphinx",
     "sphinx-copybutton",
-    "black",
+    "tox",
     "types-redis",
     "types-requests",
 ]
@@ -77,3 +78,6 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 norecursedirs = ["bin", "lib", "include", "build"]
+
+[tool.ruff]
+target-version = "py38"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,5 +160,5 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     try:
         cherrypy.server.stop()
-    except:
+    except:  # noqa: E722
         pass

--- a/tests/issue_263.py
+++ b/tests/issue_263.py
@@ -13,9 +13,6 @@ clogger.addHandler(logging.StreamHandler())
 clogger.setLevel(logging.DEBUG)
 
 
-from pprint import pprint
-
-
 class NoAgeHeuristic(BaseHeuristic):
     def update_headers(self, response):
         if "cache-control" in response.headers:

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -5,6 +5,7 @@
 """
 Unit tests that verify our caching methods work correctly.
 """
+
 import time
 from tempfile import mkdtemp
 from unittest.mock import ANY, Mock
@@ -175,7 +176,7 @@ class TestCacheControllerResponse:
 
         This is the shared utility for any cache object.
         """
-        # Cache starts out prepopulated wih an entry:
+        # Cache starts out prepopulated with an entry:
         etag = "jfd9094r808"
         cc = CacheController(cache)
         url = "http://localhost:123/x"

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -5,6 +5,7 @@
 """
 Test for supporting redirect caches as needed.
 """
+
 import requests
 
 from cachecontrol import CacheControl

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import pickle
 from unittest.mock import Mock
 
 import msgpack

--- a/tests/test_storage_filecache.py
+++ b/tests/test_storage_filecache.py
@@ -5,6 +5,7 @@
 """
 Unit tests that verify FileCache storage works correctly.
 """
+
 import os
 import string
 


### PR DESCRIPTION
This Action uses minimal steps to run in ~5 seconds to rapidly:
* use `codespell` to look for typos in the codebase, and
* use `ruff` to lint Python code and provide intuitive GitHub Annotations to contributors.

Tools:
* https://github.com/codespell-project/codespell#readme
* https://docs.astral.sh/ruff

% `codespell --write-changes`
```
./docs/index.rst:69: sucessfully ==> successfully
./docs/tips.rst:46: tranferring ==> transferring
./docs/etags.rst:21: presense ==> presence
./cachecontrol/filewrapper.py:41: vaguaries ==> vagaries
./cachecontrol/filewrapper.py:44: thigns ==> things
./tests/test_cache_control.py:178: wih ==> with
```
% `ruff check --target-version=py38`
```
Error: cachecontrol/caches/file_cache.py:9:39: F401 `typing.Union` imported but unused
Error: tests/conftest.py:163:5: E722 Do not use bare `except`
Error: tests/issue_263.py:16:1: E402 Module level import not at top of file
Error: tests/issue_263.py:16:20: F401 `pprint.pprint` imported but unused
Error: tests/test_serialization.py:5:8: F401 `pickle` imported but unused
Error: Process completed with exit code 1.
```