### PR TITLE
Close a potentially unclosed body file before it can interfere with writing a new one

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -277,9 +277,11 @@ class CacheController:
 
     def conditional_headers(self, request: PreparedRequest) -> dict[str, str]:
         resp = self._load_from_cache(request)
-        new_headers = {}
+        if not resp:
+            return {}
+        with resp:
+            new_headers = {}
 
-        if resp:
             headers: CaseInsensitiveDict[str] = CaseInsensitiveDict(resp.headers)
 
             if "etag" in headers:
@@ -288,7 +290,7 @@ class CacheController:
             if "last-modified" in headers:
                 new_headers["If-Modified-Since"] = headers["Last-Modified"]
 
-        return new_headers
+            return new_headers
 
     def _cache_set(
         self,


### PR DESCRIPTION
This is based on debugging in https://github.com/python-trio/trio/pull/3127 and some comments from @graingert, so see that PR for specific information on what was failing (I minimized a failing example) and testing this fix for it (latest commit). Just look at the relevant github actions logs.

---

This problem only manifests on the combination of PyPy and Windows. Here's how:
 - `CacheControlAdapter#send` calls `conditional_headers`
 - `conditional_headers` calls `_load_from_cache`
 - `_load_from_cache` calls `body_file = self.cache.get_body(cache_url)` and saves it to the response
 - `get_body` returns an `open`ed file
 - `conditional_headers` uses the response (which holds the body file) to get headers
 - `conditional_headers` returns, but doesn't explicitly finish the request
   - on cpython this is fine -- refcounting means the file gets closed
   - on pypy, this keeps the file open for a while longer
 - `CacheControlAdapter#send` now runs `super().send(request, stream, timeout, verify, cert, proxies)`
   - this makes the request (good)
   - and saves the body of the new response. note that the body file may still be open on pypy (bad)
     - on unix it is OK that the bodyfile is open and we are trying to `os.replace` it
     - but on windows it is not OK

Thus an annoying caching bug happens. Hopefully I've described it well enough.