### PR TITLE
tests: explicitly GC for PyPy in test_do_not_leak_response

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import gc
+import platform
 import weakref
 from unittest import mock
 
@@ -82,6 +83,12 @@ class TestSessionActions:
         # We should not break this.
 
         resp = None
+        if platform.python_implementation() == "PyPy":
+            # NOTE: Need to explicitly tell PyPy to collect at this point.
+            # See: https://github.com/psf/cachecontrol/issues/351
+            # See: https://doc.pypy.org/en/latest/cpython_differences.html#differences-related-to-garbage-collection-strategies
+            gc.collect()
+
         # Below this point, it should be closed because there are no more references
         # to the session response.
 


### PR DESCRIPTION
I've done this only for PyPy by sniffing `platform`, since technically this should be unobservable behavior.

Fixes #351.