### PR TITLE
Convert license metadata to the PEP 639 format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.module]
@@ -13,7 +13,8 @@ name = "CacheControl"
 dynamic = ["version"]
 description = "httplib2 caching for requests"
 readme = "README.rst"
-license = { file = "LICENSE.txt" }
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 authors = [
     { name = "Eric Larson", email = "ericlarson@ionrock.com" },
     { name = "Frost Ming", email = "me@frostming.com" },
@@ -22,7 +23,6 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
The old license classifiers and the `project.license` table have been deprecated.