### PR TITLE
cache temporary redirects with explicit caching directives

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Collection, Mapping
 
 from requests.structures import CaseInsensitiveDict
 
+from cachecontrol.heuristics import HEURISTICALLY_CACHEABLE_STATUSES
 from cachecontrol.cache import DictCache, SeparateBodyBaseCache
 from cachecontrol.serialize import Serializer
 
@@ -32,6 +33,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 URI = re.compile(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?")
+
+NEVER_CACHE_STATUSES = (
+    # Per https://www.rfc-editor.org/rfc/rfc9111.html#section-3 the status
+    # code must be final
+    100,
+    101,
+    # From httplib2: Don't cache 206's since we aren't going to
+    #                handle byte range requests
+    206,
+)
+
 
 PERMANENT_REDIRECT_STATUSES = (301, 308)
 
@@ -60,7 +72,20 @@ class CacheController:
         self.cache = DictCache() if cache is None else cache
         self.cache_etags = cache_etags
         self.serializer = serializer or Serializer()
-        self.cacheable_status_codes = status_codes or (200, 203, 300, 301, 308)
+        # Per https://www.rfc-editor.org/rfc/rfc9111.html#section-3-2.7.1 all
+        # all final response codes are potentially cacheable, subject to the
+        # other conditions.  CacheController conservatively only caches common
+        # ones codes.  For example, even with a max-age set, a 500 Internal
+        # Server Error will not be cached
+        self.cacheable_status_codes = status_codes or (
+            200,
+            203,
+            300,
+            301,
+            302,
+            307,
+            308,
+        )
 
     @classmethod
     def _urlnorm(cls, uri: str) -> str:
@@ -128,12 +153,12 @@ class CacheController:
                 except IndexError:
                     if required:
                         logger.debug(
-                            "Missing value for cache-control " "directive: %s",
+                            "Missing value for cache-control directive: %s",
                             directive,
                         )
                 except ValueError:
                     logger.debug(
-                        "Invalid value for cache-control directive " "%s, must be %s",
+                        "Invalid value for cache-control directive %s, must be %s",
                         directive,
                         typ.__name__,
                     )
@@ -343,12 +368,11 @@ class CacheController:
         else:
             response = response_or_ref
 
-        # From httplib2: Don't cache 206's since we aren't going to
-        #                handle byte range requests
-        cacheable_status_codes = status_codes or self.cacheable_status_codes
-        if response.status not in cacheable_status_codes:
+        if response.status in NEVER_CACHE_STATUSES:
             logger.debug(
-                "Status code %s not in %s", response.status, cacheable_status_codes
+                "Status code %s in never cache set %s",
+                response.status,
+                NEVER_CACHE_STATUSES,
             )
             return
 
@@ -377,6 +401,30 @@ class CacheController:
 
         cc_req = self.parse_cache_control(request.headers)
         cc = self.parse_cache_control(response_headers)
+
+        # "at least one of the following" from
+        # https://www.rfc-editor.org/rfc/rfc9111.html#section-3-2.7.1
+        has_explicit_freshness = (
+            "public" in cc or "expires" in response_headers or "max-age" in cc
+            # NOTE: s-maxage is also listed in the RFC section, but
+            # cache_response() doesn't currently express the concept of shared
+            # vs private caching
+        )
+        cacheable_status_codes = status_codes or self.cacheable_status_codes
+        if response.status not in cacheable_status_codes:
+            logger.debug(
+                "Status code %s not in %s", response.status, cacheable_status_codes
+            )
+            return
+        if (
+            response.status not in HEURISTICALLY_CACHEABLE_STATUSES
+            and not has_explicit_freshness
+        ):
+            logger.debug(
+                "Status code %s is not heuristically cacheable and no explicit caching headers are set",
+                response.status,
+            )
+            return
 
         assert request.url is not None
         cache_url = self.cache_url(request.url)

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -72,11 +72,11 @@ class CacheController:
         self.cache = DictCache() if cache is None else cache
         self.cache_etags = cache_etags
         self.serializer = serializer or Serializer()
-        # Per https://www.rfc-editor.org/rfc/rfc9111.html#section-3-2.7.1 all
-        # all final response codes are potentially cacheable, subject to the
-        # other conditions.  CacheController conservatively only caches common
-        # ones codes.  For example, even with a max-age set, a 500 Internal
-        # Server Error will not be cached
+        # Per https://www.rfc-editor.org/rfc/rfc9111.html#section-3 all final
+        # response codes are potentially cacheable, subject to the other
+        # conditions.  CacheController conservatively only considers a subset
+        # that are commonly cached by widely used user agents.  For example, even
+        # with a max-age set, a 500 Internal Server Error will not be cached.
         self.cacheable_status_codes = status_codes or (
             200,
             203,

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 URI = re.compile(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?")
 
-NEVER_CACHE_STATUSES = (
+_NEVER_CACHE_STATUSES = (
     # Per https://www.rfc-editor.org/rfc/rfc9111.html#section-3 the status
     # code must be final
     100,
@@ -368,11 +368,11 @@ class CacheController:
         else:
             response = response_or_ref
 
-        if response.status in NEVER_CACHE_STATUSES:
+        if response.status in _NEVER_CACHE_STATUSES:
             logger.debug(
                 "Status code %s in never cache set %s",
                 response.status,
-                NEVER_CACHE_STATUSES,
+                _NEVER_CACHE_STATUSES,
             )
             return
 

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -14,6 +14,21 @@ if TYPE_CHECKING:
 
 TIME_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 
+# Concise list from https://www.rfc-editor.org/rfc/rfc9110#section-15.1
+HEURISTICALLY_CACHEABLE_STATUSES = {
+    200,
+    203,
+    204,
+    206,
+    300,
+    301,
+    404,
+    405,
+    410,
+    414,
+    501,
+}
+
 
 def expire_after(delta: timedelta, date: datetime | None = None) -> datetime:
     date = date or datetime.now(timezone.utc)
@@ -107,20 +122,6 @@ class LastModified(BaseHeuristic):
     Unlike mozilla we limit this to 24-hr.
     """
 
-    cacheable_by_default_statuses = {
-        200,
-        203,
-        204,
-        206,
-        300,
-        301,
-        404,
-        405,
-        410,
-        414,
-        501,
-    }
-
     def update_headers(self, resp: HTTPResponse) -> dict[str, str]:
         headers: Mapping[str, str] = resp.headers
 
@@ -130,7 +131,7 @@ class LastModified(BaseHeuristic):
         if "cache-control" in headers and headers["cache-control"] != "public":
             return {}
 
-        if resp.status not in self.cacheable_by_default_statuses:
+        if resp.status not in HEURISTICALLY_CACHEABLE_STATUSES:
             return {}
 
         if "date" not in headers or "last-modified" not in headers:


### PR DESCRIPTION
RFC 9111 §3 - Storing Responses in Caches, describes the conditions under which a cache may store a response.  Notably all final (aka not 1xx) status codes are *potentially* cacheable, subject to the other listed conditions.

In brief a response must have either an explicit header (such as a `max-age` directive) OR have a heuristically cacheable status code. Which status codes are heuristically cacheable is helpfully summarized in RFC 9110 §15.1 - Overview of Status Codes: 200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, and 501)

CacheController has historically maintained a more conservative list of cacheable_status_codes that are a subset of the heuristically cacheable ones.

This diff makes related changes:
 * Temporary redirects are now cached by default.  Besides being correct in the general case, temporary redirects are used by several Python Registries as discussed in #384.
 * Because temporary redirects are not heuristically cacheable, add a check to only cache them when explicit headers are present.  This means that regardless of which status_codes are passed to CacheController, the HTTP specification is still followed.
 * As defensive future proofing, make sure the response is final before much else is done.

fixes #384