### PR TITLE
fix: clarify cache miss log message

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -163,7 +163,7 @@ class CacheController:
 
         result = self.serializer.loads(request, cache_data, body_file)
         if result is None:
-            logger.debug("Cache entry deserialization failed, entry ignored")
+            logger.debug("Cache entry not usable for request, entry ignored")
         return result
 
     def cached_request(self, request: PreparedRequest) -> HTTPResponse | Literal[False]:


### PR DESCRIPTION
## Summary
- clarify cache log message when a cached entry is unusable for the request
- avoids implying deserialization failure for Vary mismatches

## Testing
- /tmp/cachecontrol-venv/bin/pytest tests/test_serialization.py -q

Closes #209