### PR TITLE
fix: The new SeparateBodyFileCache design makes updates/reads non-atomic (#324)

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -158,6 +158,10 @@ class CacheController:
 
         if isinstance(self.cache, SeparateBodyBaseCache):
             body_file = self.cache.get_body(cache_url)
+            if body_file is None:
+                logger.debug("Body file missing, deleting cache entry")
+                self.cache.delete(cache_url)
+                return None
         else:
             body_file = None
 
@@ -303,6 +307,11 @@ class CacheController:
         Store the data in the cache.
         """
         if isinstance(self.cache, SeparateBodyBaseCache):
+            # body is None can happen when, for example, we're only updating
+            # headers, as is the case in update_cached_response().
+            if body is not None:
+                self.cache.set_body(cache_url, body)
+
             # We pass in the body separately; just put a placeholder empty
             # string in the metadata.
             self.cache.set(
@@ -310,10 +319,6 @@ class CacheController:
                 self.serializer.dumps(request, response, b""),
                 expires=expires_time,
             )
-            # body is None can happen when, for example, we're only updating
-            # headers, as is the case in update_cached_response().
-            if body is not None:
-                self.cache.set_body(cache_url, body)
         else:
             self.cache.set(
                 cache_url,


### PR DESCRIPTION
Fixes #324

## Summary
Fixes non-atomic updates/reads for `SeparateBodyFileCache` by ensuring the body is written before metadata. On read, it now verifies that both metadata and body files are present, treating an entry as invalid if the body is missing.

## Validation
Tests passing after 1 attempt(s).

```
tests/test_expires_heuristics.py ................                        [ 59%]
tests/test_max_age.py ..                                                 [ 61%]
tests/test_redirects.py ....                                             [ 65%]
tests/test_regressions.py ..                                             [ 67%]
tests/test_serialization.py ..........                                   [ 77%]
tests/test_server_http_version.py .                                      [ 78%]
tests/test_storage_filecache.py ..................                       [ 96%]
tests/test_storage_redis.py ...                                          [ 99%]
tests/test_vary.py .                                                     [100%]
============================= 101 passed in 2.98s ==============================
```
