### PR TITLE
fix: HTTPResponse object has no attribute 'chunked' (#137)

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -131,7 +131,7 @@ class CacheControlAdapter(HTTPAdapter):
                         self.controller.cache_response, request, weakref.ref(response)
                     ),
                 )
-                if response.chunked:
+                if getattr(response, "chunked", False):
                     super_update_chunk_length = response.__class__._update_chunk_length
 
                     def _update_chunk_length(


### PR DESCRIPTION
Fixes #137

## Summary
The `chunked` attribute on `urllib3.response.HTTPResponse` is not present in older versions of the library, which can be used by older versions of `requests`. This change uses `getattr` to safely access the attribute, preventing an `AttributeError`.

## Validation
Tests passing after 1 attempt(s).

```
tests/test_expires_heuristics.py ................                        [ 59%]
tests/test_max_age.py ..                                                 [ 61%]
tests/test_redirects.py ....                                             [ 65%]
tests/test_regressions.py ..                                             [ 67%]
tests/test_serialization.py ..........                                   [ 77%]
tests/test_server_http_version.py .                                      [ 78%]
tests/test_storage_filecache.py ..................                       [ 96%]
tests/test_storage_redis.py ...                                          [ 99%]
tests/test_vary.py .                                                     [100%]
============================= 101 passed in 3.18s ==============================
```
