### PR TITLE
fix: Head request is not cached even with cacheable_methods=("GET", HEAD") without a previous GET (#337)

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -372,6 +372,7 @@ class CacheController:
             and "content-length" in response_headers
             and response_headers["content-length"].isdigit()
             and int(response_headers["content-length"]) != len(body)
+            and request.method != "HEAD"
         ):
             return
 

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -112,6 +112,25 @@ class TestCacheControllerResponse:
 
         assert not cc.cache.set.called
 
+    def test_cache_response_head_request(self, cc):
+        now = time.strftime(TIME_FMT, time.gmtime())
+        req = self.req()
+        req.method = "HEAD"
+
+        resp = self.resp(
+            {
+                "cache-control": "max-age=3600",
+                "date": now,
+                "Content-Length": "1234",
+            }
+        )
+        # HEAD responses have no body
+        resp.read = lambda **k: b""
+
+        cc.cache_response(req, resp, body=b"")
+        cc.serializer.dumps.assert_called_with(req, resp, b"")
+        cc.cache.set.assert_called_with(self.url, ANY, expires=3600)
+
     def test_no_cache_with_vary_star(self, cc):
         # Vary: * indicates that the response can never be served
         # from the cache, so storing it can be avoided.


### PR DESCRIPTION
Fixes #337

## Summary
A HEAD request was not being cached because of a check that compares the `Content-Length` header with the actual body length. For a HEAD request, the body is empty, but `Content-Length` can be non-zero, causing the check to fail and preventing caching. The fix is to skip this check for HEAD requests.

## Validation
Tests passing after 1 attempt(s).

```
tests/test_expires_heuristics.py ................                        [ 59%]
tests/test_max_age.py ..                                                 [ 61%]
tests/test_redirects.py ....                                             [ 65%]
tests/test_regressions.py ..                                             [ 67%]
tests/test_serialization.py ..........                                   [ 77%]
tests/test_server_http_version.py .                                      [ 78%]
tests/test_storage_filecache.py ..................                       [ 96%]
tests/test_storage_redis.py ...                                          [ 99%]
tests/test_vary.py .                                                     [100%]
============================= 102 passed in 3.03s ==============================
```
