### PR TITLE
fix(controller): Recover from invalid dates

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -219,7 +219,9 @@ class CacheController:
 
         now = time.time()
         time_tuple = parsedate_tz(headers["date"])
-        assert time_tuple is not None
+        if time_tuple is None:
+            logger.debug("Ignoring cached response: invalid date")
+            return False
         date = calendar.timegm(time_tuple[:6])
         current_age = max(0, now - date)
         logger.debug("Current age based on date: %i", current_age)
@@ -358,8 +360,7 @@ class CacheController:
 
         if "date" in response_headers:
             time_tuple = parsedate_tz(response_headers["date"])
-            assert time_tuple is not None
-            date = calendar.timegm(time_tuple[:6])
+            date = calendar.timegm(time_tuple[:6]) if time_tuple is not None else 0
         else:
             date = 0
 
@@ -430,7 +431,8 @@ class CacheController:
         # the cache.
         elif "date" in response_headers:
             time_tuple = parsedate_tz(response_headers["date"])
-            assert time_tuple is not None
+            if time_tuple is None:
+                return
             date = calendar.timegm(time_tuple[:6])
             # cache when there is a max-age > 0
             max_age = cc.get("max-age")

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -63,6 +63,13 @@ class TestCacheControllerResponse:
 
         assert not cc.cache.set.called
 
+    def test_no_cache_with_malformed_date(self, cc):
+        # An unparseable date must not crash; treat it like a missing date
+        resp = self.resp({"cache-control": "max-age=3600", "date": "garbage"})
+        cc.cache_response(self.req(), resp)
+
+        assert not cc.cache.set.called
+
     def test_no_cache_with_wrong_sized_body(self, cc):
         # When the body is the wrong size, then we don't want to cache it
         # because it is obviously broken.
@@ -301,6 +308,16 @@ class TestCacheControlRequest:
         now = time.strftime(TIME_FMT, time.gmtime())
         # Not a valid header; this would be from a misconfigured server
         resp = Mock(headers={"cache-control": "max-age=xxx", "date": now}, status=200)
+
+        self.c.cache = DictCache({self.url: resp})
+
+        assert not self.req({})
+
+    def test_cached_request_with_malformed_date_not_returned(self):
+        # A cached entry with an unparseable date must not crash the lookup
+        resp = Mock(
+            headers={"cache-control": "max-age=3600", "date": "garbage"}, status=200
+        )
 
         self.c.cache = DictCache({self.url: resp})
 


### PR DESCRIPTION
Tiny hardening change that prevents a malformed Date header from crashing the controller.