### PR TITLE
fix(redis): Don't SETEX with a non-positive TTL

### DIFF
--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -25,14 +25,20 @@ class RedisCache(BaseCache):
     ) -> None:
         if not expires:
             self.conn.set(key, value)
-        elif isinstance(expires, datetime):
+            return
+
+        if isinstance(expires, datetime):
             now_utc = datetime.now(timezone.utc)
             if expires.tzinfo is None:
                 now_utc = now_utc.replace(tzinfo=None)
-            delta = expires - now_utc
-            self.conn.setex(key, int(delta.total_seconds()), value)
+            ttl = int((expires - now_utc).total_seconds())
         else:
-            self.conn.setex(key, expires, value)
+            ttl = expires
+
+        if ttl <= 0:
+            self.conn.delete(key)
+        else:
+            self.conn.setex(key, ttl, value)
 
     def delete(self, key: str) -> None:
         self.conn.delete(key)

--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -23,6 +23,8 @@ class RedisCache(BaseCache):
     def set(
         self, key: str, value: bytes, expires: int | datetime | None = None
     ) -> None:
+        """Store ``value``, optionally expiring it after ``expires``.
+        """
         if not expires:
             self.conn.set(key, value)
             return
@@ -35,10 +37,7 @@ class RedisCache(BaseCache):
         else:
             ttl = expires
 
-        if ttl <= 0:
-            self.conn.delete(key)
-        else:
-            self.conn.setex(key, ttl, value)
+        self.conn.setex(key, ttl, value)
 
     def delete(self, key: str) -> None:
         self.conn.delete(key)

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -301,9 +301,14 @@ class CacheController:
         body: bytes | None = None,
         expires_time: int | None = None,
     ) -> None:
+        """Store the data in the cache.
         """
-        Store the data in the cache.
-        """
+        if expires_time is not None and expires_time <= 0:
+            # Already stale on arrival
+            logger.debug("Purging cached response: expires in the past")
+            self.cache.delete(cache_url)
+            return
+
         if isinstance(self.cache, SeparateBodyBaseCache):
             # We pass in the body separately; just put a placeholder empty
             # string in the metadata.
@@ -452,11 +457,15 @@ class CacheController:
             elif "expires" in response_headers:
                 if response_headers["expires"]:
                     expires = parsedate_tz(response_headers["expires"])
-                    if expires is not None:
-                        expires_time = calendar.timegm(expires[:6]) - date
+                    if expires is None:
+                        # https://tools.ietf.org/html/rfc9111#section-5.3: an
+                        # invalid Expires must be read as a time in the past.
+                        expires_time = 0
                     else:
-                        expires_time = None
+                        expires_time = calendar.timegm(expires[:6]) - date
 
+                    # A non-positive lifetime here means the response arrived
+                    # stale
                     logger.debug(
                         "Caching b/c of expires header. expires in {} seconds".format(
                             expires_time

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -119,6 +119,67 @@ class TestCacheControllerResponse:
 
         assert not cc.cache.set.called
 
+    def test_cache_response_expires_in_future(self, cc):
+        now = time.time()
+        resp = self.resp(
+            {
+                "date": time.strftime(TIME_FMT, time.gmtime(now)),
+                "expires": time.strftime(TIME_FMT, time.gmtime(now + 3600)),
+            }
+        )
+        cc.cache_response(self.req(), resp)
+
+        cc.cache.set.assert_called_with(self.url, ANY, expires=3600)
+
+    @pytest.mark.parametrize(
+        "expires",
+        [
+            # RFC 9111 4.2.1: freshness lifetime is Expires - Date, which the
+            # origin is free to make negative to force revalidation.
+            "past",
+            # RFC 9111 5.3: an invalid Expires means "already expired".
+            "0",
+            "garbage",
+        ],
+    )
+    def test_cache_response_expires_in_past_not_cached(self, cc, expires):
+        now = time.time()
+        if expires == "past":
+            expires = time.strftime(TIME_FMT, time.gmtime(now - 3600))
+        resp = self.resp(
+            {"date": time.strftime(TIME_FMT, time.gmtime(now)), "expires": expires}
+        )
+        cc.cache_response(self.req(), resp)
+
+        assert not cc.cache.set.called
+
+    def test_cache_response_expires_in_past_purges_existing_entry(self):
+        now = time.time()
+        cache = DictCache({self.url: b"stale"})
+        cc = CacheController(cache, serializer=Mock())
+
+        resp = self.resp(
+            {
+                "date": time.strftime(TIME_FMT, time.gmtime(now)),
+                "expires": time.strftime(TIME_FMT, time.gmtime(now - 3600)),
+            }
+        )
+        cc.cache_response(self.req(), resp)
+
+        assert cc.cache.get(self.url) is None
+
+    @pytest.mark.parametrize("expires_time", [0, -1, -3600])
+    def test_cache_set_never_passes_non_positive_expires(self, cc, expires_time):
+        """``_cache_set`` is the only chokepoint into ``BaseCache.set``.
+
+        Backends may therefore assume ``expires`` is either None or strictly
+        positive; a non-positive deadline must purge instead of store.
+        """
+        cc._cache_set(self.url, self.req(), self.resp(), b"testing", expires_time)
+
+        assert not cc.cache.set.called
+        cc.cache.delete.assert_called_with(self.url)
+
     def test_no_cache_with_vary_star(self, cc):
         # Vary: * indicates that the response can never be served
         # from the cache, so storing it can be avoided.

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -2,64 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime, timedelta, timezone
-
-import pytest
-from redis.exceptions import ResponseError
+from datetime import datetime, timezone
+from unittest.mock import Mock
 
 from cachecontrol.caches import RedisCache
 
 
-class FakeRedis:
-    def __init__(self) -> None:
-        self.values: dict[str, bytes] = {}
-        self.ttls: dict[str, int] = {}
-
-    def set(self, key: str, value: bytes) -> None:
-        self.values[key] = value
-        self.ttls.pop(key, None)
-
-    def setex(self, key: str, seconds: int, value: bytes) -> None:
-        if seconds <= 0:
-            raise ResponseError("invalid expire time in 'setex' command")
-        self.values[key] = value
-        self.ttls[key] = seconds
-
-    def get(self, key: str) -> bytes | None:
-        return self.values.get(key)
-
-    def delete(self, key: str) -> None:
-        self.values.pop(key, None)
-        self.ttls.pop(key, None)
-
-
-ONE_HOUR = timedelta(hours=1)
-
-
 class TestRedisCache:
     def setup_method(self):
-        self.conn = FakeRedis()
+        self.conn = Mock()
         self.cache = RedisCache(self.conn)
 
-    @pytest.mark.parametrize("tzinfo", [None, timezone.utc], ids=["naive", "aware"])
-    @pytest.mark.parametrize(
-        "offset, expected",
-        [(ONE_HOUR, b"bar"), (-ONE_HOUR, None)],
-        ids=["future", "past"],
-    )
-    def test_set_expiration_datetime(self, tzinfo, offset, expected):
-        """A deadline already in the past must not reach SETEX."""
-        expires = datetime.now(timezone.utc).replace(tzinfo=tzinfo) + offset
+    def test_set_expiration_datetime(self):
+        self.cache.set("foo", "bar", expires=datetime(2014, 2, 2))
+        assert self.conn.setex.called
 
-        self.cache.set("foo", b"bar", expires=expires)
+    def test_set_expiration_datetime_aware(self):
+        self.cache.set("foo", "bar", expires=datetime(2014, 2, 2, tzinfo=timezone.utc))
+        assert self.conn.setex.called
 
-        assert self.conn.get("foo") == expected
-
-    @pytest.mark.parametrize(
-        "expires, expected", [(600, b"bar"), (-600, None)], ids=["positive", "negative"]
-    )
-    def test_set_expiration_int(self, expires, expected):
-        """controller.py computes ``Expires - Date``, which can go negative."""
-        self.cache.set("foo", b"bar", expires=expires)
-
-        assert self.conn.get("foo") == expected
+    def test_set_expiration_int(self):
+        self.cache.set("foo", "bar", expires=600)
+        assert self.conn.setex.called

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -2,25 +2,64 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime, timezone
-from unittest.mock import Mock
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from redis.exceptions import ResponseError
 
 from cachecontrol.caches import RedisCache
 
 
+class FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, bytes] = {}
+        self.ttls: dict[str, int] = {}
+
+    def set(self, key: str, value: bytes) -> None:
+        self.values[key] = value
+        self.ttls.pop(key, None)
+
+    def setex(self, key: str, seconds: int, value: bytes) -> None:
+        if seconds <= 0:
+            raise ResponseError("invalid expire time in 'setex' command")
+        self.values[key] = value
+        self.ttls[key] = seconds
+
+    def get(self, key: str) -> bytes | None:
+        return self.values.get(key)
+
+    def delete(self, key: str) -> None:
+        self.values.pop(key, None)
+        self.ttls.pop(key, None)
+
+
+ONE_HOUR = timedelta(hours=1)
+
+
 class TestRedisCache:
     def setup_method(self):
-        self.conn = Mock()
+        self.conn = FakeRedis()
         self.cache = RedisCache(self.conn)
 
-    def test_set_expiration_datetime(self):
-        self.cache.set("foo", "bar", expires=datetime(2014, 2, 2))
-        assert self.conn.setex.called
+    @pytest.mark.parametrize("tzinfo", [None, timezone.utc], ids=["naive", "aware"])
+    @pytest.mark.parametrize(
+        "offset, expected",
+        [(ONE_HOUR, b"bar"), (-ONE_HOUR, None)],
+        ids=["future", "past"],
+    )
+    def test_set_expiration_datetime(self, tzinfo, offset, expected):
+        """A deadline already in the past must not reach SETEX."""
+        expires = datetime.now(timezone.utc).replace(tzinfo=tzinfo) + offset
 
-    def test_set_expiration_datetime_aware(self):
-        self.cache.set("foo", "bar", expires=datetime(2014, 2, 2, tzinfo=timezone.utc))
-        assert self.conn.setex.called
+        self.cache.set("foo", b"bar", expires=expires)
 
-    def test_set_expiration_int(self):
-        self.cache.set("foo", "bar", expires=600)
-        assert self.conn.setex.called
+        assert self.conn.get("foo") == expected
+
+    @pytest.mark.parametrize(
+        "expires, expected", [(600, b"bar"), (-600, None)], ids=["positive", "negative"]
+    )
+    def test_set_expiration_int(self, expires, expected):
+        """controller.py computes ``Expires - Date``, which can go negative."""
+        self.cache.set("foo", b"bar", expires=expires)
+
+        assert self.conn.get("foo") == expected


### PR DESCRIPTION
RedisCache.set forwarded its expiry straight to SETEX, which Redis rejects for seconds `<=0` with an "invalid expire time" ResponseError.

(Verified against a local redis container)