### PR TITLE
Honor response no-cache before cache reuse

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -190,6 +190,15 @@ class CacheController:
         if not resp:
             return False
 
+        headers: CaseInsensitiveDict[str] = CaseInsensitiveDict(resp.headers)
+        resp_cc = self.parse_cache_control(headers)
+
+        # A response with ``no-cache`` may be stored, but it must be
+        # successfully validated with the origin server before each reuse.
+        if "no-cache" in resp_cc:
+            logger.debug('Response header has "no-cache", cache revalidation required')
+            return False
+
         # If we have a cached permanent redirect, return it immediately. We
         # don't need to test our response for other headers b/c it is
         # intrinsically "cacheable" as it is Permanent.
@@ -207,7 +216,6 @@ class CacheController:
             logger.debug(msg)
             return resp
 
-        headers: CaseInsensitiveDict[str] = CaseInsensitiveDict(resp.headers)
         if not headers or "date" not in headers:
             if "etag" not in headers:
                 # Without date or etag, the cached response can never be used
@@ -230,8 +238,6 @@ class CacheController:
         #       urllib3 response object. This may not be best since we
         #       could probably avoid instantiating or constructing the
         #       response until we know we need it.
-        resp_cc = self.parse_cache_control(headers)
-
         # determine freshness
         freshness_lifetime = 0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,18 @@ class SimpleApp:
             start_response("200 OK", headers)
         return [pformat(env).encode("utf8")]
 
+    def etag_no_cache(self, env, start_response):
+        headers = [
+            ("Etag", self.etag_string),
+            ("Cache-Control", "no-cache, max-age=5000"),
+        ]
+        if env.get("HTTP_IF_NONE_MATCH") == self.etag_string:
+            start_response("304 Not Modified", headers)
+            return []
+
+        start_response("200 OK", headers)
+        return [pformat(env).encode("utf8")]
+
     def cache_60(self, env, start_response):
         headers = [("Cache-Control", "public, max-age=60")]
         start_response("200 OK", headers)

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -251,6 +251,15 @@ class TestCacheControlRequest:
         resp = self.req({"cache-control": "no-cache"})
         assert not resp
 
+    def test_cached_permanent_redirect_with_no_cache_is_revalidated(self):
+        resp = Mock(
+            headers={"cache-control": "no-cache", "location": "/elsewhere"},
+            status=301,
+        )
+        self.c.cache = DictCache({self.url: resp})
+
+        assert not self.req({})
+
     def test_cache_request_pragma_no_cache(self):
         resp = self.req({"pragma": "no-cache"})
         assert not resp

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -23,6 +23,7 @@ class TestETag:
     @pytest.fixture()
     def sess(self, url):
         self.etag_url = urljoin(url, "/etag")
+        self.etag_no_cache_url = urljoin(url, "/etag_no_cache")
         self.update_etag_url = urljoin(url, "/update_etag")
         self.cache = DictCache()
         sess = CacheControl(
@@ -93,6 +94,17 @@ class TestETag:
         # This response does come from the cache, but only after the 304 response from
         # the server told us that was fine.
         assert r.from_cache
+
+    def test_response_no_cache_requires_revalidation(self, sess):
+        """A response's ``no-cache`` directive requires revalidation."""
+        response = sess.get(self.etag_no_cache_url)
+        assert "if-none-match" not in response.request.headers
+
+        response = sess.get(self.etag_no_cache_url)
+
+        assert "if-none-match" in response.request.headers
+        assert response.status_code == 200
+        assert response.from_cache
 
     def test_etags_get_with_range(self, sess, server):
         """A 'Range' header stops us from using the cache altogether."""


### PR DESCRIPTION
## Summary

- Parse cached response directives before permanent-redirect and freshness shortcuts.
- Require origin revalidation whenever a stored response includes `Cache-Control: no-cache`.
- Preserve normal conditional ETag reuse after a successful `304 Not Modified` response.

Closes #132.

## Validation

- Both new regressions fail on unmodified `master` and pass with this patch.
- Full test suite: 105 passed.
- Focused cache-control and ETag tests: 36 passed.
- Ruff lint and formatting, strict mypy, and Git whitespace checks passed.

AI assistance is disclosed in the commit trailer.
