### PR TITLE
Invalidate cached responses after POST

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class CacheControlAdapter(HTTPAdapter):
-    invalidating_methods = {"PUT", "PATCH", "DELETE"}
+    invalidating_methods = {"POST", "PUT", "PATCH", "DELETE"}
 
     def __init__(
         self,

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -62,6 +62,11 @@ class TestSessionActions:
         sess.get(url)
         assert not r2.from_cache
 
+    def test_post_invalidates_cache(self, url, sess):
+        sess.get(url)
+        sess.post(url, data={"foo": "bar"})
+        assert not sess.get(url).from_cache
+
     def test_close(self):
         cache = mock.Mock(spec=DictCache)
         sess = Session()


### PR DESCRIPTION
`CacheControlAdapter.invalidating_methods` lists `PUT`, `PATCH` and `DELETE`, but not `POST`.
A successful POST therefore leaves a previously cached GET for the same URL in place, and the
next GET is served from the cache with the pre-POST body.

RFC 9111 §4.4 requires invalidation on any unsafe method and names POST in the first sentence:

> Because unsafe request methods (Section 9.2.1 of [HTTP]) such as PUT, POST, or DELETE have the
> potential for changing state on the origin server, intervening caches are required to invalidate
> stored responses to keep their contents up to date.

## Reproduction

Against a server whose GET body changes after each POST:

```
GET, POST, GET  ->  value=0 then value=0    # stale
GET, PUT,  GET  ->  value=0 then value=1    # correct
```

Same server, same handler, same headers; only the method differs.

## The change

One entry added to `invalidating_methods`, plus a test.

The three existing tests (`test_put_invalidates_cache` and friends) assert `not r2.from_cache` on
the response to the unsafe request itself, which is never served from cache regardless. The new
test asserts on the GET that follows, so it fails without the fix:

```
FAILED tests/test_adapter.py::TestSessionActions::test_post_invalidates_cache[use_adapter]
FAILED tests/test_adapter.py::TestSessionActions::test_post_invalidates_cache[use_wrapper]
```

With the change, the full suite passes (105 tests).

## Scope

This does not implement the `MAY` part of §4.4 (invalidating URIs from `Location` and
`Content-Location`), nor the "methods whose safety is unknown" clause. Both are separate changes.
