### PR TITLE
don't lower case-sensitive user info embedded in URLs

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -70,7 +70,8 @@ class CacheController:
             raise Exception("Only absolute URIs are allowed. uri = %s" % uri)
 
         scheme = scheme.lower()
-        authority = authority.lower()
+        userinfo, separator, host = authority.rpartition("@")
+        authority = f"{userinfo}{separator}{host.lower()}"
 
         if not path:
             path = "/"

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -322,3 +322,11 @@ class TestCacheControlRequest:
         self.c.cache = DictCache({self.url: resp})
 
         assert not self.req({})
+
+
+class TestCacheControllerUrlNormalization:
+    def test_cache_url_preserves_userinfo_case(self):
+        url = "HTTP://Alice:Secret@EXAMPLE.COM/resource"
+        expected_url = "http://Alice:Secret@example.com/resource"
+
+        assert CacheController.cache_url(url) == expected_url

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -127,6 +127,21 @@ class TestCacheControllerResponse:
 
         assert not cc.cache.set.called
 
+    def test_cache_response_preserves_userinfo_case(self):
+        cache = DictCache({})
+        cc = CacheController(cache)
+        url = "http://Alice:Secret@localhost/"
+        req = DummyRequest(url=url, headers={})
+        resp = DummyResponse(status=200, headers={"ETag": "xyz"})
+        cc.cache_response(req, resp, b"")
+
+        req = DummyRequest(
+            url="http://alice:secret@localhost/", headers={"if-match": "xyz"}
+        )
+        result = cc.conditional_headers(req)
+
+        assert not result
+
     def test_update_cached_response_no_local_cache(self):
         """
         If the local cache doesn't have the given URL, just reuse the response
@@ -322,11 +337,3 @@ class TestCacheControlRequest:
         self.c.cache = DictCache({self.url: resp})
 
         assert not self.req({})
-
-
-class TestCacheControllerUrlNormalization:
-    def test_cache_url_preserves_userinfo_case(self):
-        url = "HTTP://Alice:Secret@EXAMPLE.COM/resource"
-        expected_url = "http://Alice:Secret@example.com/resource"
-
-        assert CacheController.cache_url(url) == expected_url


### PR DESCRIPTION
CacheControl lowercases URL user information when constructing cache keys. Requests preserves its case and generates different Basic Authorization headers, allowing a response for one credential spelling to satisfy another.

This PR prevents the lowering of userinfo in URL and introduces a unit test for this case.