### PR TITLE
parse cache-control directive case-insensitively

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -112,7 +112,7 @@ class CacheController:
                 continue
 
             parts = cc_directive.split("=", 1)
-            directive = parts[0].strip()
+            directive = parts[0].strip().lower()
 
             try:
                 typ, required = known_directives[directive]

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -113,6 +113,14 @@ class TestCacheControllerResponse:
         cc.cache_response(self.req(), resp)
         assert not cc.cache.get(cache_url)
 
+    def test_cache_control_directives_case_insensitive(self, cc):
+        now = time.strftime(TIME_FMT, time.gmtime())
+        resp = self.resp({"cache-control": "No-Store, max-age=3600", "date": now})
+
+        cc.cache_response(self.req(), resp)
+
+        assert not cc.cache.set.called
+
     def test_cache_response_no_store_with_etag(self, cc):
         resp = self.resp({"cache-control": "no-store", "ETag": "jfd9094r808"})
         cc.cache_response(self.req(), resp)


### PR DESCRIPTION
CacheControl matches Cache-Control directive names case-sensitively, although RFC 9111 requires case-insensitive matching. Valid directives such as No-Store are therefore ignored.

This PR normalizes directive name cases and introduces a test case.