### PR TITLE
apply freshness checks to redirects with explicit expiration

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -190,23 +190,11 @@ class CacheController:
         if not resp:
             return False
 
-        # If we have a cached permanent redirect, return it immediately. We
-        # don't need to test our response for other headers b/c it is
-        # intrinsically "cacheable" as it is Permanent.
-        #
-        # See:
-        #   https://tools.ietf.org/html/rfc7231#section-6.4.2
-        #
-        # Client can try to refresh the value by repeating the request
-        # with cache busting headers as usual (ie no-cache).
-        if int(resp.status) in PERMANENT_REDIRECT_STATUSES:
-            msg = (
-                "Returning cached permanent redirect response "
-                "(ignoring date and etag information)"
-            )
-            logger.debug(msg)
-            return resp
-
+        # Apply normal freshness checks to every cached response. In the case
+        # of permanent redirects, RFC 9110 sections 15.4.2 and 15.4.9 permit
+        # heuristic caching, but RFC 9111 section 4.2.2 requires explicit
+        # expiration to take precedence. The redirect fallback below is used
+        # only when neither max-age nor Expires provides an expiration.
         headers: CaseInsensitiveDict[str] = CaseInsensitiveDict(resp.headers)
         if not headers or "date" not in headers:
             if "etag" not in headers:
@@ -248,6 +236,12 @@ class CacheController:
                 expire_time = calendar.timegm(expires[:6]) - date
                 freshness_lifetime = max(0, expire_time)
                 logger.debug("Freshness lifetime from expires: %i", freshness_lifetime)
+
+        # Permanent redirects are heuristically cacheable when the response
+        # does not provide an explicit freshness lifetime.
+        elif int(resp.status) in PERMANENT_REDIRECT_STATUSES:
+            logger.debug("Returning cached permanent redirect response")
+            return resp
 
         # Determine if we are setting freshness limit in the
         # request. Note, this overrides what was in the response.

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -284,6 +284,14 @@ class TestCacheControlRequest:
         r = self.req({})
         assert not r
 
+    def test_cache_request_unfresh_permanent_redirect(self):
+        earlier = time.time() - 3600
+        date = time.strftime(TIME_FMT, time.gmtime(earlier))
+        resp = Mock(headers={"cache-control": "max-age=1", "date": date}, status=301)
+        self.c.cache = DictCache({self.url: resp})
+        r = self.req({})
+        assert not r
+
     def test_cache_request_fresh_expires(self):
         later = time.time() + 86400  # GMT + 1 day
         expires = time.strftime(TIME_FMT, time.gmtime(later))


### PR DESCRIPTION
CacheControl treats stored 301 and 308 responses as permanently reusable. It returns them before evaluating response freshness or cache-control directives.

This is a bit tricky, but RFC 9111 section 4.2.2 states:

> A cache MUST NOT use heuristics to determine freshness when an explicit expiration time is present in the stored response. Because of the requirements in [Section 3](https://www.rfc-editor.org/info/rfc9111/#response.cacheability), heuristics can only be used on responses without explicit freshness whose status codes are defined as "heuristically cacheable" (e.g., see [Section 15.1](https://www.rfc-editor.org/info/rfc9110/#section-15.1) of [[HTTP](https://www.rfc-editor.org/info/rfc9111/#HTTP)]) and on responses without explicit freshness that have been marked as explicitly cacheable (e.g., with a public response directive).

If we take cachecontrol's heuristic to be "the response is permanently fresh" then (afaiu) this would mean that redirect responses with explicit expiration dates _can_ expire and thus should be checked for freshness (i.e., the explicit expiration takes precedence over the heuristic).

This PR applies the usual freshness checks to redirects, and introduces a fallback to still treat them as permanently fresh if the response is not expired. It also introduces relevant unit tests.